### PR TITLE
fix demosSandbox

### DIFF
--- a/applications/demosSandbox/sdkDemos/DemoEntityManager.h
+++ b/applications/demosSandbox/sdkDemos/DemoEntityManager.h
@@ -152,6 +152,7 @@ class DemoEntityManager: public wxGLCanvas, public dList <DemoEntity*>
 
 	void CreateOpenGlFont();
 
+	wxGLContext* m_context;	
 
 	NewtonDemos* m_mainWindow;
 	NewtonWorld* m_world;

--- a/applications/demosSandbox/sdkDemos/NewtonDemos.cpp
+++ b/applications/demosSandbox/sdkDemos/NewtonDemos.cpp
@@ -166,20 +166,20 @@ class NewtonDemosApp: public wxApp
 		NewtonSetMemorySystem (PhysicsAlloc, PhysicsFree);
 
 		int version = NewtonWorldGetVersion();
-		wxString tittle;
-		tittle.Printf (wxT ("Newton %d.%02d SDK demos"), version / 100, version % 100);
-		NewtonDemos* const frame = new NewtonDemos(tittle, wxDefaultPosition, wxSize(1024, 768));
+		wxString title;
+		title.Printf (wxT ("Newton %d.%02d SDK demos"), version / 100, version % 100);
+		NewtonDemos* const frame = new NewtonDemos(title, wxDefaultPosition, wxSize(1024, 768));
 		
 
 		frame->Show(true);
 		SetTopWindow(frame);
 
-		// initialize open gl graphics
+		// initialize opengl graphics
 		if (frame->m_scene) {
 			frame->m_scene->InitGraphicsSystem();
 		}
 
-		// load the default Scene		
+		// load the default Scene
 		wxMenuEvent loadDemo (wxEVT_COMMAND_MENU_SELECTED, NewtonDemos::ID_RUN_DEMO + DEFAULT_SCENE);
 		frame->GetEventHandler()->ProcessEvent(loadDemo);
 
@@ -556,8 +556,7 @@ void NewtonDemos::LoadDemo (int index)
 	BEGIN_MENU_OPTION();
 
 	m_scene->Cleanup();
-
-	m_scene->SetCurrent();
+    
 	m_demosSelection[index].m_launchDemoCallback (m_scene);
 	m_scene->SwapBuffers(); 
 


### PR DESCRIPTION
small fix for the demosSandbox to successfully initialize openGL on Linux.
Added some more error handling and replaced a depreciated wxWidgets call with a supported one (other param order in constructor).
Now the window doesn't stay gray any more :smiley:
