### PR TITLE
Build fix for Mac - CLOCK_REALTIME not found.

### DIFF
--- a/coreLibrary_300/source/core/dgTypes.h
+++ b/coreLibrary_300/source/core/dgTypes.h
@@ -821,5 +821,20 @@ DG_INLINE void dgPrefetchMem(const void* const mem)
 	#endif
 }
 
+#ifdef __MACH__
+#include <sys/time.h>
+#define CLOCK_REALTIME 0
+#define CLOCK_MONOTONIC 0
+//clock_gettime is not implemented on OSX
+DG_INLINE int clock_gettime(int /*clk_id*/, struct timespec* t) {
+    struct timeval now;
+    int rv = gettimeofday(&now, NULL);
+    if (rv) return rv;
+    t->tv_sec  = now.tv_sec;
+    t->tv_nsec = now.tv_usec * 1000;
+    return 0;
+}
+#endif
+
 #endif
 


### PR DESCRIPTION
Was getting compile failures on Mac OS X, got a solution from: http://stackoverflow.com/a/9781275/441352
