### PR TITLE
minor cmake fixes

### DIFF
--- a/applications/demosSandbox/CMakeLists.txt
+++ b/applications/demosSandbox/CMakeLists.txt
@@ -59,7 +59,7 @@ if (UNIX)
   add_definitions(-DD_JOINTLIBRARY_STATIC_LIB)
 
   if (BUILD_64)
-    add_definitions(-D_POSIX_VER_64)
+    add_definitions(-D_POSIX_VER -D_POSIX_VER_64)
   else (BUILD_64)
     add_definitions(-D_POSIX_VER)
   endif (BUILD_64)

--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -60,11 +60,7 @@ target_link_libraries(dVisualDebuggerServer ${ENet_LIBRARY})
 
 
 if (UNIX)
-  if (BUILD_64)
-    add_definitions(-D_POSIX_VER_64)
-  else (BUILD_64)
-    add_definitions(-D_POSIX_VER_64)
-  endif (BUILD_64)
+  add_definitions(-D_POSIX_VER)
 endif(UNIX)
 
 if (CMAKE_COMPILER_IS_GNUCC)


### PR DESCRIPTION
Apparently ` _POSIX_VER` should also be defined when building on 64 bit linux. ` _POSIX_VER_64` is not needed in packages.