### PR TITLE
Improve CMake for timeTracker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,9 @@ endif ()
 option("NEWTON_DEMOS_SANDBOX" "Build demos sandbox" ON)
 
 
+add_subdirectory("${NewtonSDK_SOURCE_DIR}/packages")
 add_subdirectory("${NewtonSDK_SOURCE_DIR}/packages/thirdParty")
 add_subdirectory("${NewtonSDK_SOURCE_DIR}/coreLibrary_300")
-add_subdirectory("${NewtonSDK_SOURCE_DIR}/packages")
 
 if(NEWTON_DEMOS_SANDBOX)
   add_subdirectory("${NewtonSDK_SOURCE_DIR}/applications/demosSandbox")

--- a/packages/thirdParty/CMakeLists.txt
+++ b/packages/thirdParty/CMakeLists.txt
@@ -13,3 +13,4 @@ file(GLOB timeTracker_srcs timeTracker/dTimeTracker.cpp)
 add_library(timeTracker ${timeTracker_srcs})
 
 target_include_directories(timeTracker PUBLIC timeTracker/)
+target_link_libraries(timeTracker dMath dContainers)

--- a/packages/thirdParty/timeTracker/stdafx.h
+++ b/packages/thirdParty/timeTracker/stdafx.h
@@ -5,13 +5,15 @@
 
 #pragma once
 
-#include "targetver.h"
+#if defined(_MSC_VER)
+  #include "targetver.h"
 
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
-// Windows Header Files:
-#include <windows.h>
-#include <intrin.h>
-#include <time.h>
+  #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+  // Windows Header Files:
+  #include <windows.h>
+  #include <intrin.h>
+  #include <time.h>
+#endif
 
 #include <dContainersStdAfx.h>
 #include <dContainersAlloc.h>


### PR DESCRIPTION
This further improves the CMake for the time tracker (dependency on dContainers and dMath) and hopefully puts the **#ifdef** in the right place.