### PR TITLE
Compile fixes for iOS

### DIFF
--- a/coreLibrary_300/source/core/dgTypes.cpp
+++ b/coreLibrary_300/source/core/dgTypes.cpp
@@ -571,8 +571,10 @@ dgFloatExceptions::dgFloatExceptions(dgUnsigned32 mask)
 	#endif
 
 	#ifdef _MACOSX_VER
-		fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
-	#else 
+		#ifndef IOS
+			fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
+		#endif
+	#else
 		_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 	#endif
 

--- a/coreLibrary_300/source/core/dgVector.h
+++ b/coreLibrary_300/source/core/dgVector.h
@@ -600,7 +600,7 @@ class dgVector
 
 	DG_INLINE dgVector ShiftRightLogical (int bits) const
 	{
-		return dgVector (dgUnsigned32 (m_ix) >> bits, dgUnsigned32 (m_iy) >> bits, dgUnsigned32 (m_iz) >> bits, dgUnsigned32 (m_iw) >> bits); 
+		return dgVector ((dgInt32) (dgUnsigned32 (m_ix) >> bits), dgUnsigned32 (m_iy) >> bits, dgUnsigned32 (m_iz) >> bits, dgUnsigned32 (m_iw) >> bits);
 	}
 
 	DG_INLINE static void Transpose4x4 (dgVector& dst0, dgVector& dst1, dgVector& dst2, dgVector& dst3, const dgVector& src0, const dgVector& src1, const dgVector& src2, const dgVector& src3)
@@ -653,6 +653,21 @@ class dgVector
 class dgSpatialVector
 {
 public:
+
+	DG_INLINE dgSpatialVector()
+	{
+		SetZero();
+	}
+
+	DG_INLINE dgSpatialVector(const dgVector& low, const dgVector& high)
+	{
+		m_v[0] = low[0];
+		m_v[1] = low[1];
+		m_v[2] = low[2];
+		m_v[3] = high[0];
+		m_v[4] = high[1];
+		m_v[5] = high[2];
+	}
 
 	DG_INLINE dgFloat64& operator[] (dgInt32 i)
 	{
@@ -1621,10 +1636,8 @@ class dgSpatialMatrix
 
 	DG_INLINE void SetZero()
 	{
-		dgVector zero (dgVector::m_zero);
 		for (dgInt32 i = 0; i < 6; i++) {
-			m_rows[i].m_l = zero;
-			m_rows[i].m_h = zero;
+			m_rows[i].SetZero();
 		}
 	}
 

--- a/coreLibrary_300/source/physics/dgSkeletonContainer.cpp
+++ b/coreLibrary_300/source/physics/dgSkeletonContainer.cpp
@@ -213,7 +213,11 @@ class dgSkeletonContainer::dgGraph
 		for (dgInt32 i = 0; i < dof ; i++) {
 			const dgSpatialVector& jacobian = jacobianMatrix[i];
 			for (dgInt32 j = 0; j < dof ; j++) {
-				dgAssert(dgAreEqual (childDiagonal[i][j], childDiagonal[j][i], dgFloat32(1.0e-5f)));
+				#ifdef DG_SCALAR_VECTOR_CLASS
+					dgAssert(dgAreEqual (childDiagonal[i][j], childDiagonal[j][i], dgFloat64(1.0e-5f)));
+				#else
+					dgAssert(dgAreEqual (childDiagonal[i][j], childDiagonal[j][i], dgFloat32(1.0e-5f)));
+				#endif
 				dgFloat32 val = childDiagonal[i][j];
 				jacobian.ScaleAdd(val, copy[j], copy[j]);
 			}


### PR DESCRIPTION
-dgSpatialVector constructors / SetZero
-float32 vs float64 assert
-don't set SSE float environment