### PR TITLE
Fixed false not being convertible to void*

### DIFF
--- a/coreLibrary_300/source/meshUtil/dgMeshEffect3.cpp
+++ b/coreLibrary_300/source/meshUtil/dgMeshEffect3.cpp
@@ -561,7 +561,7 @@ class dgHACDClusterGraph: public dgGraph<dgHACDCluster, dgHACDEdge>
 
 			dgFloat64 param = dgFloat32 (100.0f);
 			if (clusterFace->m_color != m_clusterA->m_color) {
-				param = dgMeshEffect::dgMeshBVH::RayFaceIntersect (face, p1, p0, false);
+				param = dgMeshEffect::dgMeshBVH::RayFaceIntersect (face, p1, p0, NULL);
 				if ((param >= dgFloat32 (0.0f)) && (param <= dgFloat32(1.0f))) {
 					param = dgFloat32 (1.0f) - param;
 				}


### PR DESCRIPTION
After pulling in new changes I wasn't able to compile. 

I didn't know how to fix: 
```
In file included from /home/hhyyrylainen/Projects/newton-dynamics/coreLibrary_300/source/core/dgGeneralMatrix.cpp:23:0:
/home/hhyyrylainen/Projects/newton-dynamics/coreLibrary_300/source/core/dgGeneralMatrix.h: Funktio ”void dgCholeskyInverse(dgInt32, T*, T*)”:
/home/hhyyrylainen/Projects/newton-dynamics/coreLibrary_300/source/core/dgGeneralMatrix.h:82:35: virhe: ”row” on esittelemättä tällä näkyvyysalueella
   T invDiag = T(dgFloat32(1.0f) / row[i]);
```

So I used an older commit and was able to fix it by replacing `false` with `NULL`