### PR TITLE
Fixed links to files in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Compiling Newton
 ## Windows and OSX
 Project files for Visual Studio and XCode are provided, mainly
 
-* Newton Core: [coreLibrary_300/projects/](coreLibrary_300/projects/)
-* packages: [packages/projects/](packages/projects/)
+* Newton Core and packages: [sdk/projects/](sdk/projects/)
 * demo sandbox: [applications/demosSandbox/projects/](applications/demosSandbox/projects/)
 
 ## Linux
@@ -30,7 +29,7 @@ To build the demo sandbox the following packages need to be installed:
 
 All of these should be available on any major Linux distribution (with associated `-dev` or `-devel` packages).
 
-Alternatively they can be found in the folder [packages/thirdParty/](packages/thirdParty/) and built from source.
+Alternatively they can be found in the folder [sdk/thirdParty/](sdk/thirdParty/) and built from source.
 
 
 License


### PR DESCRIPTION
Just realized, that the links in the readme also need to be adapted to the structure change.
Please merge 😉 