### PR TITLE
Fix to pure virtual method called with threads

### DIFF
--- a/sdk/dgCore/dgThread.cpp
+++ b/sdk/dgCore/dgThread.cpp
@@ -133,6 +133,10 @@ dgThread::~dgThread ()
 
 void dgThread::Init ()
 {
+	// This must be set now because otherwise if this thread is
+	// immediately closed the Terminate method won't detect that the
+	// thread is running
+	dgInterlockedExchange(&m_threadRunning, 1);
 	m_handle = std::thread(dgThreadSystemCallback, this);
 	dgThreadYield();
 }
@@ -162,7 +166,6 @@ void* dgThread::dgThreadSystemCallback(void* threadData)
 
 	dgThread* const me = (dgThread*) threadData;
 
-	dgInterlockedExchange(&me->m_threadRunning, 1);
 	me->Execute(me->m_id);
 	dgInterlockedExchange(&me->m_threadRunning, 0);
 	dgThreadYield();


### PR DESCRIPTION
Moved m_threadRunning setting to dgThread::Init

In my tests this fixed my issue: https://github.com/MADEAPPS/newton-dynamics/issues/88
And this thread on the forums: http://newtondynamics.com/forum/viewtopic.php?f=12&t=9232