### PR TITLE
On Windows, the `thirdParty` directory is included/added twice.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,5 @@ add_subdirectory("${NewtonSDK_SOURCE_DIR}/sdk")
 
 # demos sandbox
 if(NEWTON_DEMOS_SANDBOX)
-  add_subdirectory("${NewtonSDK_SOURCE_DIR}/sdk/thirdParty")
   add_subdirectory("${NewtonSDK_SOURCE_DIR}/applications/demosSandbox")
 endif()

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -10,10 +10,10 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-if(WIN32)
+if(WIN32 OR NEWTON_DEMOS_SANDBOX)
   # Required dependencies
   add_subdirectory(thirdParty)
-endif(WIN32)
+endif()
 
 file(GLOB dgCore_srcs dgCore/*.cpp)               # low level core
 file(GLOB dgMeshUtil_srcs dgMeshUtil/*.cpp)       # mesh geometry


### PR DESCRIPTION
Causing the CMake build system to throw an error when demos and sandbox are built as well.