### PR TITLE
Some Small Fixes/Changes

### DIFF
--- a/sdk/dCustomJoints/dCustom6dof.h
+++ b/sdk/dCustomJoints/dCustom6dof.h
@@ -62,8 +62,10 @@ class dCustom6dof: public dCustomJoint
 	CUSTOM_JOINTS_API dFloat GetRoll() const { return m_roll.m_currentAngle.GetAngle();}
 	CUSTOM_JOINTS_API dFloat GetPitch() const { return m_pitch.m_currentAngle.GetAngle();}
 
-	protected:
-	CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+    CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
+    protected:
+
 	CUSTOM_JOINTS_API virtual void SubmitConstraints (dFloat timestep, int threadIndex);
 	CUSTOM_JOINTS_API virtual void Deserialize (NewtonDeserializeCallback callback, void* const userData);
 	CUSTOM_JOINTS_API virtual void Serialize (NewtonSerializeCallback callback, void* const userData) const;

--- a/sdk/dCustomJoints/dCustomBallAndSocket.h
+++ b/sdk/dCustomJoints/dCustomBallAndSocket.h
@@ -38,9 +38,9 @@ class dCustomBallAndSocket: public dCustomJoint
 
 	CUSTOM_JOINTS_API void SetTwistSpringDamper(bool state, dFloat springDamperRelaxation, dFloat spring, dFloat damper);
 
-
+    CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
 	protected:
-	CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+	
 	CUSTOM_JOINTS_API virtual void Deserialize (NewtonDeserializeCallback callback, void* const userData);
 	CUSTOM_JOINTS_API virtual void Serialize (NewtonSerializeCallback callback, void* const userData) const; 
 	CUSTOM_JOINTS_API virtual void SubmitConstraints (dFloat timestep, int threadIndex);

--- a/sdk/dCustomJoints/dCustomCorkScrew.h
+++ b/sdk/dCustomJoints/dCustomCorkScrew.h
@@ -31,10 +31,13 @@ class dCustomCorkScrew: public dCustomSlider
 
 	CUSTOM_JOINTS_API void SetAsSpringDamper(bool state, dFloat springDamperRelaxation, dFloat spring, dFloat damper);
 
-	protected:
+    CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
+
+    protected:
 	CUSTOM_JOINTS_API virtual void Deserialize (NewtonDeserializeCallback callback, void* const userData);
 	CUSTOM_JOINTS_API virtual void Serialize (NewtonSerializeCallback callback, void* const userData) const; 
-	CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
 	CUSTOM_JOINTS_API virtual void SubmitAngularRow(const dMatrix& matrix0, const dMatrix& matrix1, dFloat timestep);
 	void SubmitConstraintLimits(const dMatrix& matrix0, const dMatrix& matrix1, dFloat timestep);
 	void SubmitConstraintSpringDamper(const dMatrix& matrix0, const dMatrix& matrix1, dFloat timestep);

--- a/sdk/dCustomJoints/dCustomDoubleHinge.h
+++ b/sdk/dCustomJoints/dCustomDoubleHinge.h
@@ -37,8 +37,10 @@ class dCustomDoubleHinge: public dCustomHinge
 
 	CUSTOM_JOINTS_API void SetHardMiddleAxis(bool state);
 
-	protected:
-	CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+    CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
+protected:
+
 	CUSTOM_JOINTS_API virtual void Deserialize(NewtonDeserializeCallback callback, void* const userData);
 	CUSTOM_JOINTS_API virtual void Serialize(NewtonSerializeCallback callback, void* const userData) const;
 	CUSTOM_JOINTS_API virtual void SubmitAngularRow(const dMatrix& matrix0, const dMatrix& matrix1, const dVector& eulers, dFloat timestep);

--- a/sdk/dCustomJoints/dCustomHinge.h
+++ b/sdk/dCustomJoints/dCustomHinge.h
@@ -39,8 +39,11 @@ class dCustomHinge: public dCustomJoint
 	CUSTOM_JOINTS_API void EnableMotor(bool state, dFloat motorSpeed);
 	CUSTOM_JOINTS_API void SetAsSpringDamper(bool state, dFloat springDamperRelaxation, dFloat spring, dFloat damper);
 
-	protected:
-	CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
+    CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
+    protected:
+	
 	CUSTOM_JOINTS_API virtual void SubmitConstraints (dFloat timestep, int threadIndex);
 	CUSTOM_JOINTS_API virtual void Deserialize (NewtonDeserializeCallback callback, void* const userData); 
 	CUSTOM_JOINTS_API virtual void Serialize (NewtonSerializeCallback callback, void* const userData) const; 

--- a/sdk/dCustomJoints/dCustomInverseDynamics.h
+++ b/sdk/dCustomJoints/dCustomInverseDynamics.h
@@ -252,8 +252,10 @@ class dCustomInverseDynamics: public dCustomJoint
 	CUSTOM_JOINTS_API void SetTwistAngle(dFloat minAngle, dFloat maxAngle);
 	CUSTOM_JOINTS_API void GetTwistAngle(dFloat& minAngle, dFloat& maxAngle) const;
 
-	protected:
-	CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+    CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
+    protected:
+	
 	CUSTOM_JOINTS_API virtual void Deserialize(NewtonDeserializeCallback callback, void* const userData);
 	CUSTOM_JOINTS_API virtual void Serialize(NewtonSerializeCallback callback, void* const userData) const;
 	CUSTOM_JOINTS_API virtual void SubmitConstraints(dFloat timestep, int threadIndex);

--- a/sdk/dCustomJoints/dCustomKinematicController.cpp
+++ b/sdk/dCustomJoints/dCustomKinematicController.cpp
@@ -180,27 +180,37 @@ void dCustomKinematicController::SubmitConstraints (dFloat timestep, int threadI
 		NewtonUserJointSetRowMaximumFriction(m_joint, m_maxLinearFriction);
 	}	
 
-
-
 	if (m_isSixdof) {
 		dQuaternion rotation (matrix0.Inverse() * m_targetMatrix);
-        rotation.Normalize();
+		if (dAbs (rotation.m_q0) < 0.99998f) {
+			dMatrix rot (dGrammSchmidt(dVector (rotation.m_q1, rotation.m_q2, rotation.m_q3)));
+			dFloat angle = 2.0f * dAcos(dClamp(rotation.m_q0, dFloat(-1.0f), dFloat(1.0f)));
 
+			NewtonUserJointAddAngularRow (m_joint, angle, &rot.m_front[0]);
+			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
+			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
 
-        dMatrix rot(dGrammSchmidt(dVector(rotation.m_q1, rotation.m_q2, rotation.m_q3)));
-        dFloat angle = 2.0f * dAcos(dClamp(rotation.m_q0, dFloat(-1.0f), dFloat(1.0f)));
+			NewtonUserJointAddAngularRow (m_joint, 0.0f, &rot.m_up[0]);
+			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
+			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
 
-        NewtonUserJointAddAngularRow(m_joint, angle, &rot.m_front[0]);
-        NewtonUserJointSetRowMinimumFriction(m_joint, -m_maxAngularFriction);
-        NewtonUserJointSetRowMaximumFriction(m_joint, m_maxAngularFriction);
+			NewtonUserJointAddAngularRow (m_joint, 0.0f, &rot.m_right[0]);
+			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
+			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
 
-        NewtonUserJointAddAngularRow(m_joint, 0.0f, &rot.m_up[0]);
-        NewtonUserJointSetRowMinimumFriction(m_joint, -m_maxAngularFriction);
-        NewtonUserJointSetRowMaximumFriction(m_joint, m_maxAngularFriction);
+		} else {
+			NewtonUserJointAddAngularRow (m_joint, 0.0f, &matrix0.m_front[0]);
+			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
+			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
 
-        NewtonUserJointAddAngularRow(m_joint, 0.0f, &rot.m_right[0]);
-        NewtonUserJointSetRowMinimumFriction(m_joint, -m_maxAngularFriction);
-        NewtonUserJointSetRowMaximumFriction(m_joint, m_maxAngularFriction);
+			NewtonUserJointAddAngularRow (m_joint, 0.0f, &matrix0.m_up[0]);
+			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
+			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
+
+			NewtonUserJointAddAngularRow (m_joint, 0.0f, &matrix0.m_right[0]);
+			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
+			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
+		}
 	}
 }
 

--- a/sdk/dCustomJoints/dCustomKinematicController.cpp
+++ b/sdk/dCustomJoints/dCustomKinematicController.cpp
@@ -74,6 +74,7 @@ void dCustomKinematicController::Init (NewtonBody* const body, const dMatrix& ma
 	NewtonBodySetSleepState(body, 0);
 
 	SetPickMode(1);
+    SetLimitRotationVelocity(true);
 	SetTargetMatrix(matrix);
 	SetMaxLinearFriction(1.0f);
 	SetMaxAngularFriction(1.0f);
@@ -85,6 +86,11 @@ void dCustomKinematicController::Init (NewtonBody* const body, const dMatrix& ma
 void dCustomKinematicController::SetPickMode (int mode)
 {
 	m_isSixdof = mode ? true : false;
+}
+
+void dCustomKinematicController::SetLimitRotationVelocity(int limit)
+{
+
 }
 
 void dCustomKinematicController::SetMaxLinearFriction(dFloat frictionForce)
@@ -147,14 +153,17 @@ void dCustomKinematicController::SubmitConstraints (dFloat timestep, int threadI
 	dAssert (timestep > 0.0f);
 	const dFloat invTimestep = 1.0f / timestep;
 
-	// we not longer cap excessive angular velocities, it is left to the client application. 
+
 	NewtonBodyGetOmega(m_body0, &omega[0]);
 	dFloat mag2 = omega.DotProduct3(omega);
-	if (mag2 > dFloat32(10.0f * 10.0f)) {
-		omega = omega.Normalize().Scale(10.0f);
-		NewtonBodySetOmega(m_body0, &omega[0]);
-	}
 
+    //cap excessive angular velocities
+    if (m_limitRotVel) {
+        if (mag2 > dFloat32(10.0f * 10.0f)) {
+            omega = omega.Normalize().Scale(10.0f);
+            NewtonBodySetOmega(m_body0, &omega[0]);
+        }
+    }
 	// calculate the position of the pivot point and the Jacobian direction vectors, in global space. 
 	dVector relPosit(m_targetMatrix.m_posit - matrix0.m_posit);
 	NewtonBodyGetPointVelocity(m_body0, &m_targetMatrix.m_posit[0], &pointVeloc[0]);

--- a/sdk/dCustomJoints/dCustomKinematicController.cpp
+++ b/sdk/dCustomJoints/dCustomKinematicController.cpp
@@ -180,37 +180,27 @@ void dCustomKinematicController::SubmitConstraints (dFloat timestep, int threadI
 		NewtonUserJointSetRowMaximumFriction(m_joint, m_maxLinearFriction);
 	}	
 
+
+
 	if (m_isSixdof) {
 		dQuaternion rotation (matrix0.Inverse() * m_targetMatrix);
-		if (dAbs (rotation.m_q0) < 0.99998f) {
-			dMatrix rot (dGrammSchmidt(dVector (rotation.m_q1, rotation.m_q2, rotation.m_q3)));
-			dFloat angle = 2.0f * dAcos(dClamp(rotation.m_q0, dFloat(-1.0f), dFloat(1.0f)));
+        rotation.Normalize();
 
-			NewtonUserJointAddAngularRow (m_joint, angle, &rot.m_front[0]);
-			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
-			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
 
-			NewtonUserJointAddAngularRow (m_joint, 0.0f, &rot.m_up[0]);
-			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
-			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
+        dMatrix rot(dGrammSchmidt(dVector(rotation.m_q1, rotation.m_q2, rotation.m_q3)));
+        dFloat angle = 2.0f * dAcos(dClamp(rotation.m_q0, dFloat(-1.0f), dFloat(1.0f)));
 
-			NewtonUserJointAddAngularRow (m_joint, 0.0f, &rot.m_right[0]);
-			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
-			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
+        NewtonUserJointAddAngularRow(m_joint, angle, &rot.m_front[0]);
+        NewtonUserJointSetRowMinimumFriction(m_joint, -m_maxAngularFriction);
+        NewtonUserJointSetRowMaximumFriction(m_joint, m_maxAngularFriction);
 
-		} else {
-			NewtonUserJointAddAngularRow (m_joint, 0.0f, &matrix0.m_front[0]);
-			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
-			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
+        NewtonUserJointAddAngularRow(m_joint, 0.0f, &rot.m_up[0]);
+        NewtonUserJointSetRowMinimumFriction(m_joint, -m_maxAngularFriction);
+        NewtonUserJointSetRowMaximumFriction(m_joint, m_maxAngularFriction);
 
-			NewtonUserJointAddAngularRow (m_joint, 0.0f, &matrix0.m_up[0]);
-			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
-			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
-
-			NewtonUserJointAddAngularRow (m_joint, 0.0f, &matrix0.m_right[0]);
-			NewtonUserJointSetRowMinimumFriction (m_joint, -m_maxAngularFriction);
-			NewtonUserJointSetRowMaximumFriction (m_joint,  m_maxAngularFriction);
-		}
+        NewtonUserJointAddAngularRow(m_joint, 0.0f, &rot.m_right[0]);
+        NewtonUserJointSetRowMinimumFriction(m_joint, -m_maxAngularFriction);
+        NewtonUserJointSetRowMaximumFriction(m_joint, m_maxAngularFriction);
 	}
 }
 

--- a/sdk/dCustomJoints/dCustomKinematicController.h
+++ b/sdk/dCustomJoints/dCustomKinematicController.h
@@ -30,6 +30,7 @@ class dCustomKinematicController: public dCustomJoint
 	CUSTOM_JOINTS_API virtual ~dCustomKinematicController();
 
 	CUSTOM_JOINTS_API void SetPickMode (int mode);
+    CUSTOM_JOINTS_API void SetLimitRotationVelocity(int limit);
 	CUSTOM_JOINTS_API void SetMaxLinearFriction(dFloat force); 
 	CUSTOM_JOINTS_API void SetMaxAngularFriction(dFloat torque); 
 	
@@ -54,6 +55,7 @@ class dCustomKinematicController: public dCustomJoint
 	dFloat m_maxLinearFriction;
 	dFloat m_maxAngularFriction;
 	bool m_isSixdof;
+    bool m_limitRotVel;
 	bool m_autoSleepState;
 
 	DECLARE_CUSTOM_JOINT(dCustomKinematicController, dCustomJoint)

--- a/sdk/dCustomJoints/dCustomRackAndPinion.h
+++ b/sdk/dCustomJoints/dCustomRackAndPinion.h
@@ -32,7 +32,6 @@ class dCustomRackAndPinion: public dCustomJoint
 	CUSTOM_JOINTS_API virtual ~dCustomRackAndPinion();
 
 	protected:
-	//CUSTOM_JOINTS_API dCustomRackAndPinion (NewtonBody* const child, NewtonBody* const parent, NewtonDeserializeCallback callback, void* const userData);
 	CUSTOM_JOINTS_API virtual void Deserialize (NewtonDeserializeCallback callback, void* const userData);
 	CUSTOM_JOINTS_API virtual void Serialize (NewtonSerializeCallback callback, void* const userData) const; 
 

--- a/sdk/dCustomJoints/dCustomSlider.h
+++ b/sdk/dCustomJoints/dCustomSlider.h
@@ -35,9 +35,11 @@ class dCustomSlider: public dCustomJoint
 	
 	CUSTOM_JOINTS_API dFloat GetFriction () const;
 	CUSTOM_JOINTS_API void SetFriction (dFloat friction);
-	
+
+    CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
 	protected:
-	CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+	
 	CUSTOM_JOINTS_API virtual void Deserialize (NewtonDeserializeCallback callback, void* const userData); 
 	CUSTOM_JOINTS_API virtual void Serialize (NewtonSerializeCallback callback, void* const userData) const; 
 	CUSTOM_JOINTS_API virtual void SubmitConstraints (dFloat timestep, int threadIndex);

--- a/sdk/dCustomJoints/dCustomSlidingContact.h
+++ b/sdk/dCustomJoints/dCustomSlidingContact.h
@@ -31,10 +31,12 @@ class dCustomSlidingContact: public dCustomSlider
 	CUSTOM_JOINTS_API void SetAngularLimits(dFloat minAngle, dFloat maxAngle);
 	CUSTOM_JOINTS_API void SetAsAngularSpringDamper(bool state, dFloat springDamperRelaxation, dFloat spring, dFloat damper);
 
+    CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
 	protected:
 	CUSTOM_JOINTS_API virtual void Deserialize(NewtonDeserializeCallback callback, void* const userData);
 	CUSTOM_JOINTS_API virtual void Serialize(NewtonSerializeCallback callback, void* const userData) const;
-	CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+	
 	CUSTOM_JOINTS_API virtual void SubmitAngularRow(const dMatrix& matrix0, const dMatrix& matrix1, dFloat timestep);
 	CUSTOM_JOINTS_API virtual void SubmitAnglarStructuralRows(const dMatrix& matrix0, const dMatrix& matrix1, dFloat timestep);
 

--- a/sdk/dCustomJoints/dCustomVehicleControllerManager.h
+++ b/sdk/dCustomJoints/dCustomVehicleControllerManager.h
@@ -201,11 +201,14 @@ class dWheelJoint: public dCustomJoint
 		return m_lateralDir.Scale(NewtonUserJointGetRowForce(m_joint, 0));
 	}
 
+
+    CUSTOM_JOINTS_API void Debug(dDebugDisplay* const debugDisplay) const;
+
 	protected:
 	CUSTOM_JOINTS_API void ResetTransform();
 	CUSTOM_JOINTS_API dFloat CalculateTireParametricPosition(const dMatrix& tireMatrix, const dMatrix& chassisMatrix) const;
 	CUSTOM_JOINTS_API void SubmitConstraints(dFloat timestep, int threadIndex);
-	CUSTOM_JOINTS_API void Debug(dDebugDisplay* const debugDisplay) const;
+	
 
 	dVector m_lateralDir;
 	dVector m_longitudinalDir;

--- a/sdk/dCustomJoints/dCustomWheel.h
+++ b/sdk/dCustomJoints/dCustomWheel.h
@@ -34,10 +34,12 @@ class dCustomWheel: public dCustomSlidingContact
 	CUSTOM_JOINTS_API dFloat GetSteerRate() const;
 	CUSTOM_JOINTS_API void SetSteerRate(dFloat rate);
 
+    CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+
 	protected:
 	CUSTOM_JOINTS_API virtual void Deserialize(NewtonDeserializeCallback callback, void* const userData);
 	CUSTOM_JOINTS_API virtual void Serialize(NewtonSerializeCallback callback, void* const userData) const;
-	CUSTOM_JOINTS_API virtual void Debug(dDebugDisplay* const debugDisplay) const;
+	
 	CUSTOM_JOINTS_API virtual void SubmitAnglarStructuralRows(const dMatrix& matrix0, const dMatrix& matrix1, dFloat timestep);
 
 	dFloat m_steerAngle;

--- a/sdk/dgNewton/Newton.cpp
+++ b/sdk/dgNewton/Newton.cpp
@@ -3424,14 +3424,14 @@ int NewtonTreeCollisionGetVertexListTriangleListInAABB(const NewtonCollision* co
   Create a height field collision geometry.
 
   @param *newtonWorld Pointer to the Newton world.
-  @param width fixme
-  @param height fixme
+  @param width the number of sample points in the x direction (fixme)
+  @param height the number of sample points in the y direction (fixme)
   @param gridsDiagonals fixme
   @param elevationdatType fixme
-  @param elevationMap fixme
-  @param attributeMap fixme
-  @param verticalScale fixme
-  @param horizontalScale fixme
+  @param elevationMap array holding elevation data of size = width*height (fixme)
+  @param attributeMap array holding attribute data of size = width*height (fixme)
+  @param verticalScale scale of the elevation (fixme)
+  @param horizontalScale scale in the xy direction. (fixme)
   @param shapeID fixme
 
   @return Pointer to the collision.


### PR DESCRIPTION
I moved Debug() from protected to public on the custom joints classes.  This made it a lot easier for me to call because I sub-classed dDebugDisplay and wanted to simply call the Debug function on joint without sub-classing them or going through the sandbox stuff.