### PR TITLE
CMake: Downgrade required cmake to 3.4 expecting that none of the newer features are really used anyway.

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -8,7 +8,7 @@
 # including commercial applications, and to alter it and redistribute it
 # freely.
 
-cmake_minimum_required(VERSION 3.12.0)
+cmake_minimum_required(VERSION 3.4.0)
 
 include_directories(dMath/)
 include_directories(dgCore/)


### PR DESCRIPTION
This change makes it a bit easier to use on older build systems and non of the newer features seem to be used currently.