### PR TITLE
Fixes for Windows MSVC non Visual Studio builds

### DIFF
--- a/applications/demosSandbox/CMakeLists.txt
+++ b/applications/demosSandbox/CMakeLists.txt
@@ -64,9 +64,10 @@ if(MSVC)
         endif ()
     endif(NEWTON_BUILD_SHARED_LIBS)
 
-    set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/Yutoolbox_stdafx.h")
-    set_source_files_properties(sdkDemos/toolBox/toolbox_stdafx.cpp PROPERTIES COMPILE_FLAGS "/Yctoolbox_stdafx.h")
-
+    if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+        set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/Yutoolbox_stdafx.h")
+        set_source_files_properties(sdkDemos/toolBox/toolbox_stdafx.cpp PROPERTIES COMPILE_FLAGS "/Yctoolbox_stdafx.h")
+    endif()
 endif(MSVC)
 
 if (UNIX)

--- a/sdk/dAnimation/CMakeLists.txt
+++ b/sdk/dAnimation/CMakeLists.txt
@@ -38,8 +38,11 @@ if (MSVC)
 	endif(NOT NEWTON_BUILD_SHARED_LIBS)
 
     add_library(${projectName} STATIC ${CPP_SOURCE})
-    set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudAnimationStdAfx.h")
-    set_source_files_properties(dAnimationStdAfx.cpp PROPERTIES COMPILE_FLAGS "/YcdAnimationStdAfx.h")
+
+    if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+        set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudAnimationStdAfx.h")
+        set_source_files_properties(dAnimationStdAfx.cpp PROPERTIES COMPILE_FLAGS "/YcdAnimationStdAfx.h")
+    endif()
 endif(MSVC)
 
 install(TARGETS ${projectName}

--- a/sdk/dContainers/CMakeLists.txt
+++ b/sdk/dContainers/CMakeLists.txt
@@ -54,7 +54,7 @@ if (MSVC)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD
 			COMMAND ${CMAKE_COMMAND}
-			ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+			ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 	endif ()
 endif(MSVC)
 

--- a/sdk/dContainers/CMakeLists.txt
+++ b/sdk/dContainers/CMakeLists.txt
@@ -48,8 +48,11 @@ if(UNIX)
 endif(UNIX)
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudContainersStdAfx.h")
-	set_source_files_properties(dContainersStdAfx.cpp PROPERTIES COMPILE_FLAGS "/YcdContainersStdAfx.h")
+    if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+	    set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudContainersStdAfx.h")
+        set_source_files_properties(dContainersStdAfx.cpp PROPERTIES COMPILE_FLAGS "/YcdContainersStdAfx.h")
+    endif()
+
 	if (NEWTON_BUILD_SANDBOX_DEMOS)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD

--- a/sdk/dCustomJoints/CMakeLists.txt
+++ b/sdk/dCustomJoints/CMakeLists.txt
@@ -47,8 +47,11 @@ if (NEWTON_BUILD_PROFILER)
 endif()
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudCustomJointLibraryStdAfx.h")
-	set_source_files_properties(dCustomJointLibraryStdAfx.cpp PROPERTIES COMPILE_FLAGS "/YcdCustomJointLibraryStdAfx.h")
+    if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+        set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudCustomJointLibraryStdAfx.h")
+        set_source_files_properties(dCustomJointLibraryStdAfx.cpp PROPERTIES COMPILE_FLAGS "/YcdCustomJointLibraryStdAfx.h")
+    endif()
+
 	if (NEWTON_BUILD_SANDBOX_DEMOS)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD

--- a/sdk/dCustomJoints/CMakeLists.txt
+++ b/sdk/dCustomJoints/CMakeLists.txt
@@ -53,7 +53,7 @@ if (MSVC)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD
 			COMMAND ${CMAKE_COMMAND}
-			ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+			ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 	endif ()
 endif(MSVC)
 

--- a/sdk/dMath/CMakeLists.txt
+++ b/sdk/dMath/CMakeLists.txt
@@ -32,9 +32,12 @@ if (UNIX)
 endif (UNIX)
 
 if (MSVC)
-    add_library(${projectName} STATIC ${CPP_SOURCE})
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudStdAfxMath.h")
-	set_source_files_properties(dStdAfxMath.cpp PROPERTIES COMPILE_FLAGS "/YcdStdAfxMath.h")
+   add_library(${projectName} STATIC ${CPP_SOURCE})
+
+   if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+      set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudStdAfxMath.h")
+      set_source_files_properties(dStdAfxMath.cpp PROPERTIES COMPILE_FLAGS "/YcdStdAfxMath.h")
+   endif()
 endif(MSVC)
 
 install(TARGETS ${projectName}

--- a/sdk/dNewton/CMakeLists.txt
+++ b/sdk/dNewton/CMakeLists.txt
@@ -54,8 +54,11 @@ if (NEWTON_BUILD_PROFILER)
 endif()
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudStdAfxNewton.h")
-	set_source_files_properties(dStdAfxNewton.cpp PROPERTIES COMPILE_FLAGS "/YcdStdAfxNewton.h")
+    if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+	    set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudStdAfxNewton.h")
+        set_source_files_properties(dStdAfxNewton.cpp PROPERTIES COMPILE_FLAGS "/YcdStdAfxNewton.h")
+    endif()
+
 	if (NEWTON_BUILD_SANDBOX_DEMOS)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD

--- a/sdk/dNewton/CMakeLists.txt
+++ b/sdk/dNewton/CMakeLists.txt
@@ -60,7 +60,7 @@ if (MSVC)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD
 			COMMAND ${CMAKE_COMMAND}
-			ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+			ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 	endif ()
 endif(MSVC)
 

--- a/sdk/dProfiler/dTimeTracker/CMakeLists.txt
+++ b/sdk/dProfiler/dTimeTracker/CMakeLists.txt
@@ -22,8 +22,11 @@ add_library(${projectName} SHARED ${CPP_SOURCE})
 
 if (MSVC)
 	target_link_libraries (${projectName} ws2_32.lib)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/Yustdafx.h")
-	set_source_files_properties(stdafx.cpp PROPERTIES COMPILE_FLAGS "/Ycstdafx.h")
+
+	if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+		set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/Yustdafx.h")
+		set_source_files_properties(stdafx.cpp PROPERTIES COMPILE_FLAGS "/Ycstdafx.h")
+	endif()
 endif(MSVC)
 
 install(TARGETS ${projectName}

--- a/sdk/dProfiler/dTimeTracker/CMakeLists.txt
+++ b/sdk/dProfiler/dTimeTracker/CMakeLists.txt
@@ -37,5 +37,5 @@ if (NEWTON_BUILD_SANDBOX_DEMOS)
 	add_custom_command(
 		TARGET ${projectName} POST_BUILD
 		COMMAND ${CMAKE_COMMAND}
-		ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+		ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 endif ()

--- a/sdk/dScene/CMakeLists.txt
+++ b/sdk/dScene/CMakeLists.txt
@@ -55,7 +55,7 @@ if (MSVC)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD
 			COMMAND ${CMAKE_COMMAND}
-			ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+			ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 	endif ()
 endif(MSVC)
 

--- a/sdk/dScene/CMakeLists.txt
+++ b/sdk/dScene/CMakeLists.txt
@@ -49,8 +49,11 @@ if (NEWTON_BUILD_PROFILER)
 endif()
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudSceneStdafx.h")
-	set_source_files_properties(dSceneStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdSceneStdafx.h")
+    if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+	    set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudSceneStdafx.h")
+        set_source_files_properties(dSceneStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdSceneStdafx.h")
+    endif()
+    
 	if (NEWTON_BUILD_SANDBOX_DEMOS)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD

--- a/sdk/dVehicle/CMakeLists.txt
+++ b/sdk/dVehicle/CMakeLists.txt
@@ -49,8 +49,10 @@ if (NEWTON_BUILD_PROFILER)
 endif()
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudStdafxVehicle.h")
-	set_source_files_properties(dStdafxVehicle.cpp PROPERTIES COMPILE_FLAGS "/YcdStdafxVehicle.h")
+    if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+        set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudStdafxVehicle.h")
+        set_source_files_properties(dStdafxVehicle.cpp PROPERTIES COMPILE_FLAGS "/YcdStdafxVehicle.h")
+    endif()
 
 	if (NEWTON_BUILD_SANDBOX_DEMOS)
 		add_custom_command(

--- a/sdk/dVehicle/CMakeLists.txt
+++ b/sdk/dVehicle/CMakeLists.txt
@@ -56,7 +56,7 @@ if (MSVC)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD
 			COMMAND ${CMAKE_COMMAND}
-			ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+			ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 	endif ()
 endif(MSVC)
 

--- a/sdk/dgCore/CMakeLists.txt
+++ b/sdk/dgCore/CMakeLists.txt
@@ -32,9 +32,12 @@ if (UNIX)
 endif(UNIX)
 
 if (MSVC)
-	   add_library(${projectName} STATIC ${CPP_SOURCE})
-       set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgStdAfx.h")
-       set_source_files_properties(dgTypes.cpp PROPERTIES COMPILE_FLAGS "/YcdgStdAfx.h")
+      add_library(${projectName} STATIC ${CPP_SOURCE})
+
+      if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+         set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgStdAfx.h")
+         set_source_files_properties(dgTypes.cpp PROPERTIES COMPILE_FLAGS "/YcdgStdAfx.h")
+      endif()
 endif(MSVC)
 
 install(TARGETS ${projectName}

--- a/sdk/dgNewton/CMakeLists.txt
+++ b/sdk/dgNewton/CMakeLists.txt
@@ -55,7 +55,7 @@ if (MSVC)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD
 			COMMAND ${CMAKE_COMMAND}
-			ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+			ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 	endif ()
 endif(MSVC)
 

--- a/sdk/dgNewton/CMakeLists.txt
+++ b/sdk/dgNewton/CMakeLists.txt
@@ -49,9 +49,12 @@ if(NEWTON_DOUBLE_PRECISION)
 endif()
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YuNewtonStdAfx.h")
-	set_source_files_properties(NewtonClass.cpp PROPERTIES COMPILE_FLAGS "/YcNewtonStdAfx.h")
-	if (NEWTON_BUILD_SANDBOX_DEMOS)
+    if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+	    set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YuNewtonStdAfx.h")
+        set_source_files_properties(NewtonClass.cpp PROPERTIES COMPILE_FLAGS "/YcNewtonStdAfx.h")
+    endif()
+    
+    if (NEWTON_BUILD_SANDBOX_DEMOS)
 		add_custom_command(
 			TARGET ${projectName} POST_BUILD
 			COMMAND ${CMAKE_COMMAND}

--- a/sdk/dgNewtonAvx/CMakeLists.txt
+++ b/sdk/dgNewtonAvx/CMakeLists.txt
@@ -30,8 +30,10 @@ if (NEWTON_BUILD_PROFILER)
 endif ()
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
-	set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+		set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
+		set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	endif()
 endif(MSVC)
 
 

--- a/sdk/dgNewtonAvx/CMakeLists.txt
+++ b/sdk/dgNewtonAvx/CMakeLists.txt
@@ -41,15 +41,15 @@ endif(MSVC)
 add_custom_command(
 	TARGET ${projectName} POST_BUILD
 	COMMAND ${CMAKE_COMMAND}
-	ARGS -E copy $(TargetPath) ${CMAKE_INSTALL_BINDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+	ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 
 
 if (NEWTON_BUILD_SANDBOX_DEMOS)
 	if (NEWTON_DOUBLE_PRECISION)
 		add_custom_command(TARGET ${projectName} POST_BUILD COMMAND ${CMAKE_COMMAND}
-						   ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}_double/$(TargetFileName))
+						   ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}_double/$<TARGET_FILE_NAME:${projectName}>)
 	else ()
 		add_custom_command(TARGET ${projectName} POST_BUILD COMMAND ${CMAKE_COMMAND}
-						   ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+						   ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 	endif()
 endif ()

--- a/sdk/dgNewtonAvx2/CMakeLists.txt
+++ b/sdk/dgNewtonAvx2/CMakeLists.txt
@@ -30,8 +30,10 @@ if (NEWTON_BUILD_PROFILER)
 endif ()
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
-	set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+		set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
+		set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	endif()
 endif(MSVC)
 
 

--- a/sdk/dgNewtonAvx2/CMakeLists.txt
+++ b/sdk/dgNewtonAvx2/CMakeLists.txt
@@ -41,14 +41,14 @@ endif(MSVC)
 add_custom_command(
 	TARGET ${projectName} POST_BUILD
 	COMMAND ${CMAKE_COMMAND}
-	ARGS -E copy $(TargetPath) ${CMAKE_INSTALL_BINDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+	ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 
 if (NEWTON_BUILD_SANDBOX_DEMOS)
 	if (NEWTON_DOUBLE_PRECISION)
 		add_custom_command(TARGET ${projectName} POST_BUILD COMMAND ${CMAKE_COMMAND}
-						   ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}_double/$(TargetFileName))
+						   ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}_double/$<TARGET_FILE_NAME:${projectName}>)
 	else ()
 		add_custom_command(TARGET ${projectName} POST_BUILD COMMAND ${CMAKE_COMMAND}
-						   ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+						   ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 	endif()
 endif ()

--- a/sdk/dgNewtonDx12/CMakeLists.txt
+++ b/sdk/dgNewtonDx12/CMakeLists.txt
@@ -43,12 +43,12 @@ endif(MSVC)
 add_custom_command(
 	TARGET ${projectName} POST_BUILD
 	COMMAND ${CMAKE_COMMAND}
-	ARGS -E copy $(TargetPath) ${CMAKE_INSTALL_BINDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+	ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 
 
 if (NEWTON_BUILD_SANDBOX_DEMOS)
 	add_custom_command(
 		TARGET ${projectName} POST_BUILD
 		COMMAND ${CMAKE_COMMAND}
-		ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+		ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 endif ()

--- a/sdk/dgNewtonDx12/CMakeLists.txt
+++ b/sdk/dgNewtonDx12/CMakeLists.txt
@@ -32,8 +32,10 @@ if (NEWTON_BUILD_PROFILER)
 endif()
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
-	set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+		set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
+		set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	endif()
 endif(MSVC)
 
 

--- a/sdk/dgNewtonSse/CMakeLists.txt
+++ b/sdk/dgNewtonSse/CMakeLists.txt
@@ -30,8 +30,10 @@ if (NEWTON_BUILD_PROFILER)
 		target_link_libraries (${projectName} dTimeTracker)
 endif ()
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
-	set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+		set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
+		set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	endif()
 endif(MSVC)
 
 

--- a/sdk/dgNewtonSse/CMakeLists.txt
+++ b/sdk/dgNewtonSse/CMakeLists.txt
@@ -41,12 +41,12 @@ endif(MSVC)
 add_custom_command(
 	TARGET ${projectName} POST_BUILD
 	COMMAND ${CMAKE_COMMAND}
-	ARGS -E copy $(TargetPath) ${CMAKE_INSTALL_BINDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+	ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 
 
 if (NEWTON_BUILD_SANDBOX_DEMOS)
 	add_custom_command(
 		TARGET ${projectName} POST_BUILD
 		COMMAND ${CMAKE_COMMAND}
-		ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+		ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 endif ()

--- a/sdk/dgNewtonSse4.2/CMakeLists.txt
+++ b/sdk/dgNewtonSse4.2/CMakeLists.txt
@@ -30,8 +30,10 @@ if (NEWTON_BUILD_PROFILER)
 endif ()
 
 if (MSVC)
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
-	set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+		set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
+		set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
+	endif()
 endif(MSVC)
 
 

--- a/sdk/dgNewtonSse4.2/CMakeLists.txt
+++ b/sdk/dgNewtonSse4.2/CMakeLists.txt
@@ -41,14 +41,14 @@ endif(MSVC)
 add_custom_command(
 	TARGET ${projectName} POST_BUILD
 	COMMAND ${CMAKE_COMMAND}
-	ARGS -E copy $(TargetPath) ${CMAKE_INSTALL_BINDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+	ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 
 if (NEWTON_BUILD_SANDBOX_DEMOS)
 	if (NEWTON_DOUBLE_PRECISION)
 		add_custom_command(TARGET ${projectName} POST_BUILD COMMAND ${CMAKE_COMMAND}
-						   ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}_double/$(TargetFileName))
+						   ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}_double/$<TARGET_FILE_NAME:${projectName}>)
 	else ()
 		add_custom_command(TARGET ${projectName} POST_BUILD COMMAND ${CMAKE_COMMAND}
-						   ARGS -E copy $(TargetPath) ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$(TargetFileName))
+						   ARGS -E copy $<TARGET_FILE:${projectName}> ${PROJECT_BINARY_DIR}/applications/demosSandbox/${CMAKE_CFG_INTDIR}/newtonPlugins/${CMAKE_CFG_INTDIR}/$<TARGET_FILE_NAME:${projectName}>)
 	endif()
 endif ()

--- a/sdk/dgPhysics/CMakeLists.txt
+++ b/sdk/dgPhysics/CMakeLists.txt
@@ -38,8 +38,11 @@ endif(UNIX)
 
 if (MSVC)
    add_library(${projectName} STATIC ${CPP_SOURCE})
-	set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgPhysicsStdafx.h")
-	set_source_files_properties(dgWorld.cpp PROPERTIES COMPILE_FLAGS "/YcdgPhysicsStdafx.h")
+
+   if(CMAKE_VS_MSBUILD_COMMAND OR CMAKE_VS_DEVENV_COMMAND)
+	   set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgPhysicsStdafx.h")
+      set_source_files_properties(dgWorld.cpp PROPERTIES COMPILE_FLAGS "/YcdgPhysicsStdafx.h")
+   endif()
 endif(MSVC)
 
 


### PR DESCRIPTION
This helps fix CMake generation when using the MSVC compiler without MS's Visual Studio(VS) IDE. In this case, specifically for NMake and Ninja generators. I know this is a bit strange, MSVC without VS, but on highly threaded systems, such as mine (16C/32T), VS takes ~50 seconds, and Ninja takes ~15 seconds, so I'd love to use that, and this accomplishes this.

### POST_BUILD
The first part is that the copy targets are using the VS (Visual Studio) styles target names such as $(Target...) for the POST_BUILD commands. This, of course, breaks when not using VS, so instead they've been swapped out for full target paths/names that are instead using CMake's generator expressions.

### Precompiled Headers
The second is that precompiled headers don't work well (if at all) outside of the VS IDE, so to still allow compilation without VS, the places where the PCH flags are added are now guarded by CMake variables that are only populated when using a full VS generator.