### PR TITLE
Fixed plugins on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@ option("NEWTON_BUILD_SINGLE_THREADED" "multi threaded" OFF)
 option("NEWTON_DOUBLE_PRECISION" "Generate double precision" OFF)
 option("NEWTON_STATIC_RUNTIME_LIBRARIES" "use windows static libraries" ON)
 #option("NEWTON_WITH_SSE_PLUGIN" "adding asse parallel solver" OFF)
-option("NEWTON_WITH_SSE4_PLUGIN" "adding avx parallel solver" OFF)
-option("NEWTON_WITH_AVX_PLUGIN" "adding avx parallel solver" ON)
-option("NEWTON_WITH_AVX2_PLUGIN" "adding avx parallel solver" OFF)
+option("NEWTON_WITH_SSE4_PLUGIN" "adding avx parallel solver (forces shared libs)" OFF)
+option("NEWTON_WITH_AVX_PLUGIN" "adding avx parallel solver (forces shared libs)" ON)
+option("NEWTON_WITH_AVX2_PLUGIN" "adding avx parallel solver (forces shared libs)" OFF)
 #option("NEWTON_WITH_DX12_PLUGIN" "adding direct compute 12 parallel solver" OFF)
 option("NEWTON_BUILD_SHARED_LIBS" "Build shared library" OFF)
 
@@ -88,7 +88,6 @@ if (UNIX)
 
     set(NEWTON_GENERATE_DLL OFF CACHE BOOL "" FORCE)
     set(NEWTON_STATIC_RUNTIME_LIBRARIES OFF CACHE BOOL "" FORCE)
-    set(NEWTON_WITH_AVX_PLUGIN OFF CACHE BOOL "" FORCE)
     set(NEWTON_BUILD_PROFILER OFF CACHE BOOL "" FORCE)
 
 else (UNIX)
@@ -128,6 +127,11 @@ if (MSVC)
 
 	message("CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")
 	message("CMAKE_CXX_FLAGS_RELEASE is ${CMAKE_CXX_FLAGS_RELEASE}")
+endif()
+
+if(NEWTON_WITH_SSE4_PLUGIN OR NEWTON_WITH_AVX_PLUGIN OR NEWTON_WITH_AVX2_PLUGIN)
+  # If building any of the plugins, then switch to shared libraries.
+  set(NEWTON_BUILD_SHARED_LIBS ON)
 endif()
 
 add_subdirectory(sdk)

--- a/applications/demosSandbox/sdkDemos/DemoEntityManager.cpp
+++ b/applications/demosSandbox/sdkDemos/DemoEntityManager.cpp
@@ -587,16 +587,24 @@ void DemoEntityManager::Cleanup ()
 	}
 
 #ifdef _DEBUG
-	#ifdef _NEWTON_USE_DOUBLE
-		strcat(plugInPath, "/newtonPlugins/debug_double");
+	#ifdef __linux__
+		strcat(plugInPath, "newtonPlugins");
 	#else
-		strcat(plugInPath, "/newtonPlugins/debug");
+		#ifdef _NEWTON_USE_DOUBLE
+			strcat(plugInPath, "/newtonPlugins/debug_double");
+		#else
+			strcat(plugInPath, "/newtonPlugins/debug");
+		#endif
 	#endif
 #else
-	#ifdef _NEWTON_USE_DOUBLE
-		strcat(plugInPath, "/newtonPlugins/release_double");
+	#ifdef __linux__
+		strcat(plugInPath, "newtonPlugins");
 	#else
-		strcat(plugInPath, "/newtonPlugins/release");
+		#ifdef _NEWTON_USE_DOUBLE
+			strcat(plugInPath, "/newtonPlugins/release_double");
+		#else
+			strcat(plugInPath, "/newtonPlugins/release");
+		#endif
 	#endif
 #endif
 	NewtonLoadPlugins(m_world, plugInPath);

--- a/applications/demosSandbox/sdkDemos/DemoEntityManager.cpp
+++ b/applications/demosSandbox/sdkDemos/DemoEntityManager.cpp
@@ -579,7 +579,7 @@ void DemoEntityManager::Cleanup ()
 		GetModuleFileNameA(NULL, plugInPath, 256);
 	#endif
 
-	for (int i = int(strlen(plugInPath) - 1); i; i--) {
+	for (int i = int(strlen(plugInPath) - 1); i >= 0; i--) {
 		if ((plugInPath[i] == '\\') || (plugInPath[i] == '/')) {
 			plugInPath[i] = 0;
 			break;

--- a/sdk/dgNewtonAvx/CMakeLists.txt
+++ b/sdk/dgNewtonAvx/CMakeLists.txt
@@ -16,11 +16,13 @@ message (${projectName})
 # low level core
 file(GLOB source *.cpp *.h)
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fp:fast")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /fp:fast")
+if(MSVC)
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fp:fast")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /fp:fast")
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /arch:AVX")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:AVX")
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /arch:AVX")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:AVX")
+endif()
 
 add_definitions(-DNEWTONCPU_EXPORTS)
 add_library(${projectName} SHARED ${source})
@@ -34,8 +36,9 @@ if (MSVC)
 		set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
 		set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
 	endif()
-endif(MSVC)
-
+else()
+	target_compile_options(${projectName} PRIVATE -mavx)
+endif()
 
 #install(TARGETS ${projectName} RUNTIME DESTINATION ${dllPath})
 #install(TARGETS ${projectName} ARCHIVE DESTINATION ${libraryPath})

--- a/sdk/dgNewtonAvx/dgNewtonPluginStdafx.h
+++ b/sdk/dgNewtonAvx/dgNewtonPluginStdafx.h
@@ -22,17 +22,27 @@
 #ifndef _DG_NEWTON_PLUGIN_STDADX_
 #define _DG_NEWTON_PLUGIN_STDADX_
 
-// Exclude rarely-used stuff from Windows headers
-#define WIN32_LEAN_AND_MEAN             
-#include <windows.h>
+#ifdef _WIN32
+	// Exclude rarely-used stuff from Windows headers
+	#define WIN32_LEAN_AND_MEAN             
+	#include <windows.h>
+#endif
 
 #include <dg.h>
 #include <dgPhysics.h>
 
 #ifdef NEWTONCPU_EXPORTS
-	#define NEWTONCPU_API __declspec(dllexport)
+	#ifdef _WIN32
+		#define NEWTONCPU_API __declspec (dllexport)
+	#else
+		#define NEWTONCPU_API __attribute__ ((visibility("default")))
+	#endif
 #else
-	#define NEWTONCPU_API __declspec(dllimport)
+	#ifdef _WIN32
+		#define NEWTONCPU_API __declspec (dllimport)
+	#else
+		#define NEWTONCPU_API
+	#endif
 #endif
 
 #pragma warning (disable: 4100) //unreferenced formal parameter

--- a/sdk/dgNewtonAvx/dgSolver.h
+++ b/sdk/dgNewtonAvx/dgSolver.h
@@ -25,6 +25,9 @@
 
 #include "dgPhysicsStdafx.h"
 
+#ifdef __linux__
+#include <immintrin.h>
+#endif
 
 #define DG_SOA_WORD_GROUP_SIZE	8 
 

--- a/sdk/dgNewtonAvx/dgWorldBase.cpp
+++ b/sdk/dgNewtonAvx/dgWorldBase.cpp
@@ -26,6 +26,7 @@
 // This is an example of an exported function.
 dgWorldPlugin* GetPlugin(dgWorld* const world, dgMemoryAllocator* const allocator)
 {
+#ifdef _WIN32
 	union cpuInfo
 	{
 		int m_data[4];
@@ -57,6 +58,15 @@ dgWorldPlugin* GetPlugin(dgWorld* const world, dgMemoryAllocator* const allocato
 	m_reg[2] = info.m_ecx;
 	module.m_score = _stricmp(m_vendor, "GenuineIntel") ? 2 : 3;
 	return &module;
+#elif __linux__
+	if(__builtin_cpu_supports("avx")) {
+		static dgWorldBase module(world, allocator);
+		module.m_score = 3;
+		return &module;
+	} else {
+		return NULL;
+	}
+#endif
 }
 
 dgWorldBase::dgWorldBase(dgWorld* const world, dgMemoryAllocator* const allocator)

--- a/sdk/dgNewtonAvx/dllmain.cpp
+++ b/sdk/dgNewtonAvx/dllmain.cpp
@@ -21,7 +21,7 @@
 
 #include "dgNewtonPluginStdafx.h"
 
-
+#ifdef _WIN32
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
                        LPVOID lpReserved
@@ -55,4 +55,4 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 	}
 	return TRUE;
 }
-
+#endif

--- a/sdk/dgNewtonAvx2/CMakeLists.txt
+++ b/sdk/dgNewtonAvx2/CMakeLists.txt
@@ -16,11 +16,13 @@ message (${projectName})
 # low level core
 file(GLOB source *.cpp *.h)
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fp:fast")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /fp:fast")
+if(MSVC)
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fp:fast")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /fp:fast")
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /arch:AVX2")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:AVX2")
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /arch:AVX2")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:AVX2")
+endif()
 
 add_definitions(-DNEWTONCPU_EXPORTS)
 add_library(${projectName} SHARED ${source})
@@ -34,8 +36,9 @@ if (MSVC)
 		set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
 		set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
 	endif()
-endif(MSVC)
-
+else()
+	target_compile_options(${projectName} PRIVATE -mavx2)
+endif()
 
 #install(TARGETS ${projectName} RUNTIME DESTINATION ${dllPath})
 #install(TARGETS ${projectName} ARCHIVE DESTINATION ${libraryPath})

--- a/sdk/dgNewtonAvx2/dgNewtonPluginStdafx.h
+++ b/sdk/dgNewtonAvx2/dgNewtonPluginStdafx.h
@@ -22,17 +22,27 @@
 #ifndef _DG_NEWTON_PLUGIN_STDADX_
 #define _DG_NEWTON_PLUGIN_STDADX_
 
-// Exclude rarely-used stuff from Windows headers
-#define WIN32_LEAN_AND_MEAN             
-#include <windows.h>
+#ifdef _WIN32
+	// Exclude rarely-used stuff from Windows headers
+	#define WIN32_LEAN_AND_MEAN             
+	#include <windows.h>
+#endif
 
 #include <dg.h>
 #include <dgPhysics.h>
 
 #ifdef NEWTONCPU_EXPORTS
-	#define NEWTONCPU_API __declspec(dllexport)
+	#ifdef _WIN32
+		#define NEWTONCPU_API __declspec (dllexport)
+	#else
+		#define NEWTONCPU_API __attribute__ ((visibility("default")))
+	#endif
 #else
-	#define NEWTONCPU_API __declspec(dllimport)
+	#ifdef _WIN32
+		#define NEWTONCPU_API __declspec (dllimport)
+	#else
+		#define NEWTONCPU_API
+	#endif
 #endif
 
 #pragma warning (disable: 4100) //unreferenced formal parameter

--- a/sdk/dgNewtonAvx2/dgSolver.h
+++ b/sdk/dgNewtonAvx2/dgSolver.h
@@ -25,6 +25,9 @@
 
 #include "dgPhysicsStdafx.h"
 
+#ifdef __linux__
+#include <immintrin.h>
+#endif
 
 #define DG_SOA_WORD_GROUP_SIZE	8 
 

--- a/sdk/dgNewtonAvx2/dgWorldBase.cpp
+++ b/sdk/dgNewtonAvx2/dgWorldBase.cpp
@@ -26,6 +26,7 @@
 // This is an example of an exported function.
 dgWorldPlugin* GetPlugin(dgWorld* const world, dgMemoryAllocator* const allocator)
 {
+#ifdef WIN32
 	union cpuInfo
 	{
 		int m_data[4];
@@ -62,6 +63,15 @@ dgWorldPlugin* GetPlugin(dgWorld* const world, dgMemoryAllocator* const allocato
 	m_reg[2] = info.m_ecx;
 	module.m_score = _stricmp(m_vendor, "GenuineIntel") ? 3 : 4;
 	return &module;
+#elif __linux__
+	if(__builtin_cpu_supports("avx2")) {
+		static dgWorldBase module(world, allocator);
+		module.m_score = 4;
+		return &module;
+	} else {
+		return NULL;
+	}
+#endif
 }
 
 dgWorldBase::dgWorldBase(dgWorld* const world, dgMemoryAllocator* const allocator)

--- a/sdk/dgNewtonAvx2/dgWorldBase.cpp
+++ b/sdk/dgNewtonAvx2/dgWorldBase.cpp
@@ -26,7 +26,7 @@
 // This is an example of an exported function.
 dgWorldPlugin* GetPlugin(dgWorld* const world, dgMemoryAllocator* const allocator)
 {
-#ifdef WIN32
+#ifdef _WIN32
 	union cpuInfo
 	{
 		int m_data[4];

--- a/sdk/dgNewtonAvx2/dllmain.cpp
+++ b/sdk/dgNewtonAvx2/dllmain.cpp
@@ -21,7 +21,7 @@
 
 #include "dgNewtonPluginStdafx.h"
 
-
+#ifdef _WIN32
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
                        LPVOID lpReserved
@@ -55,4 +55,4 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 	}
 	return TRUE;
 }
-
+#endif

--- a/sdk/dgNewtonSse4.2/CMakeLists.txt
+++ b/sdk/dgNewtonSse4.2/CMakeLists.txt
@@ -16,11 +16,13 @@ message (${projectName})
 # low level core
 file(GLOB source *.cpp *.h)
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fp:fast")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /fp:fast")
+if(MSVC)
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fp:fast")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /fp:fast")
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /arch:SSE2")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:SSE2")
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /arch:SSE2")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:SSE2")
+endif()
 
 add_definitions(-DNEWTONCPU_EXPORTS)
 add_library(${projectName} SHARED ${source})
@@ -34,8 +36,9 @@ if (MSVC)
 		set_target_properties(${projectName} PROPERTIES COMPILE_FLAGS "/YudgNewtonPluginStdafx.h")
 		set_source_files_properties(dgNewtonPluginStdafx.cpp PROPERTIES COMPILE_FLAGS "/YcdgNewtonPluginStdafx.h")
 	endif()
-endif(MSVC)
-
+else()
+	target_compile_options(${projectName} PRIVATE -msse4.2)
+endif()
 
 #install(TARGETS ${projectName} RUNTIME DESTINATION ${dllPath})
 #install(TARGETS ${projectName} ARCHIVE DESTINATION ${libraryPath})

--- a/sdk/dgNewtonSse4.2/dgNewtonPluginStdafx.h
+++ b/sdk/dgNewtonSse4.2/dgNewtonPluginStdafx.h
@@ -22,17 +22,27 @@
 #ifndef _DG_NEWTON_PLUGIN_STDADX_
 #define _DG_NEWTON_PLUGIN_STDADX_
 
-// Exclude rarely-used stuff from Windows headers
-#define WIN32_LEAN_AND_MEAN             
-#include <windows.h>
+#ifdef _WIN32
+	// Exclude rarely-used stuff from Windows headers
+	#define WIN32_LEAN_AND_MEAN             
+	#include <windows.h>
+#endif
 
 #include <dg.h>
 #include <dgPhysics.h>
 
 #ifdef NEWTONCPU_EXPORTS
-	#define NEWTONCPU_API __declspec(dllexport)
+	#ifdef _WIN32
+		#define NEWTONCPU_API __declspec (dllexport)
+	#else
+		#define NEWTONCPU_API __attribute__ ((visibility("default")))
+	#endif
 #else
-	#define NEWTONCPU_API __declspec(dllimport)
+	#ifdef _WIN32
+		#define NEWTONCPU_API __declspec (dllimport)
+	#else
+		#define NEWTONCPU_API
+	#endif
 #endif
 
 #pragma warning (disable: 4100) //unreferenced formal parameter

--- a/sdk/dgNewtonSse4.2/dgSolver.h
+++ b/sdk/dgNewtonSse4.2/dgSolver.h
@@ -25,6 +25,9 @@
 
 #include "dgPhysicsStdafx.h"
 
+#ifdef __linux__
+#include <immintrin.h>
+#endif
 
 #ifdef _NEWTON_USE_DOUBLE
 	#define DG_SOA_WORD_GROUP_SIZE	4 

--- a/sdk/dgNewtonSse4.2/dgWorldBase.cpp
+++ b/sdk/dgNewtonSse4.2/dgWorldBase.cpp
@@ -26,6 +26,7 @@
 // This is an example of an exported function.
 dgWorldPlugin* GetPlugin(dgWorld* const world, dgMemoryAllocator* const allocator)
 {
+#ifdef _WIN32
 	union cpuInfo
 	{
 		int m_data[4];
@@ -57,6 +58,15 @@ dgWorldPlugin* GetPlugin(dgWorld* const world, dgMemoryAllocator* const allocato
 	m_reg[2] = info.m_ecx;
 	module.m_score = _stricmp(m_vendor, "GenuineIntel") ? 4 : 2;
 	return &module;
+#elif __linux__
+		if(__builtin_cpu_supports("sse4.2")) {
+		static dgWorldBase module(world, allocator);
+		module.m_score = 2;
+		return &module;
+	} else {
+		return NULL;
+	}
+#endif
 }
 
 dgWorldBase::dgWorldBase(dgWorld* const world, dgMemoryAllocator* const allocator)

--- a/sdk/dgNewtonSse4.2/dllmain.cpp
+++ b/sdk/dgNewtonSse4.2/dllmain.cpp
@@ -21,7 +21,7 @@
 
 #include "dgNewtonPluginStdafx.h"
 
-
+#ifdef _WIN32
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
                        LPVOID lpReserved
@@ -52,4 +52,4 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 	__cpuid(info.m_data, 1);
 	return ((info.m_ecx & (1 << 12)) && (info.m_ecx & (1 << 20))) ? TRUE : FALSE;
 }
-
+#endif

--- a/sdk/dgPhysics/dgWorldPlugins.h
+++ b/sdk/dgPhysics/dgWorldPlugins.h
@@ -82,6 +82,7 @@ class dgWorldPluginList: public dgList<dgWorldPluginModulePair>
 
 	private:
 	void LoadVisualStudioPlugins(const char* const path);
+	void LoadLinuxPlugins(const char* const path);
 
 	dgListNode* m_currentPlugin;
 	dgListNode* m_preferedPlugin;


### PR DESCRIPTION
This adds plugin loading/unloading code for the Linux platform, and changes required for the three currently available plugins, SSE4.2, AVX and AVX2.

As well, minor changes to the CMake script, so that when building any of the plugins, it then enforces shared libraries as required for plugin use.