### PR TITLE
Fix pointer cast warnings on 64-bit *nix

### DIFF
--- a/sdk/dgCore/dgTypes.h
+++ b/sdk/dgCore/dgTypes.h
@@ -552,7 +552,11 @@ DG_INLINE void* dgInterlockedExchange(void** const ptr, void* value)
 		#endif
 	#elif (defined (_POSIX_VER) || defined (_POSIX_VER_64) ||defined (_MACOSX_VER))
 		//__sync_synchronize();
-		return (void*)__sync_lock_test_and_set((int32_t*)ptr, value);
+		#ifdef __x86_64__
+		return (void*)__sync_lock_test_and_set((dgInt64*) ptr, value);
+		#else
+		return (void*)__sync_lock_test_and_set((dgInt32*) ptr, value);
+		#endif
 	#else
 		#error "dgInterlockedExchange implementation required"
 	#endif


### PR DESCRIPTION
Hi,

Having recently discovered the Newton Dynamics library, I'd like to start by saying... Thank You.

Imagine being me, needing a specific, accurate kind of a physics engine, knowing that I need such an engine... And trying to harness Bullet. And, of course, miserably failing. Stationary blocks exploded, intercontinental ballistic missiles went through the continents they were supposed to hit. And the API supposed to patch all that up was unclear.

Imagine learning that PhysX recently went open source, bringing with that release more accurate physics. And searching how to use it, horrified by the [EULA](https://developer.nvidia.com/gameworks-source-sdk-eula), [weird arbitrary limitations](https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/platformreadme/android/readme_android.html), code bloat...

Imagine then stumbling upon [a heated discussion](https://www.leadwerks.com/community/topic/16192-physx-fails-newton-sails/) on whether PhysX is a better engine, or Newton.

And imagine finding out that Newton Dynamics - something I had never heard of before - is a thing, is a truly free SDK *and* is better. [I](https://www.youtube.com/watch?v=Zi5P6z_PA98) [needed](https://www.youtube.com/watch?v=ejdbYssqaL4) [a](https://www.youtube.com/watch?v=zOJk_jpRnHo) [lot](https://www.youtube.com/watch?v=UlErvZoU7Q0) [to](https://www.youtube.com/watch?v=BCVQFoPO5qQ) [believe](https://www.youtube.com/watch?v=6BnFIyZsa1g). [And](https://www.youtube.com/watch?v=_FUqXxA_zZI) [received](https://www.youtube.com/watch?v=lfMrHYoyzIA).

So... Thank You. Thank You for making Newton Dynamics. Thank You for maintaining it. Thank You for fighting for its recognition. Thank You!!!

Following this obligatory preamble, I'd like to submit a small pull request that aims to fix the compilation warnings that currently appear when a 64-bit build of Newton core is made on *nixes, owing to the varying pointer sizes between 32- and 64-bit architectures.

P.S. Not exactly worthy of a separate pull request or issue, but wouldn't it be better if the demo sandbox opened a stable scene on launch, like *Using the newton mesh tool*? Baffled me for a while as to why it segfaults, until I found in the code that it tries to load the WIP vehicles by default... :)