### PR TITLE
Fix defines for DG_*_VECTOR_ALIGMENT/DG_*_AVX_ALIGMENT

### DIFF
--- a/sdk/dMath/dMathDefines.h
+++ b/sdk/dMath/dMathDefines.h
@@ -102,7 +102,7 @@
 #endif
 
 
-#define	D_MSC_VECTOR_ALIGMENT
+#define	D_MSC_VECTOR_ALIGNMENT
 
 enum dEulerAngleOrder
 {

--- a/sdk/dMath/dQuaternion.h
+++ b/sdk/dMath/dQuaternion.h
@@ -15,7 +15,7 @@
 #include "dVector.h"
 class dMatrix;
 
-D_MSC_VECTOR_ALIGMENT
+D_MSC_VECTOR_ALIGNMENT
 class dQuaternion
 {
 	public:

--- a/sdk/dgCore/dgAABBPolygonSoup.cpp
+++ b/sdk/dgCore/dgAABBPolygonSoup.cpp
@@ -31,7 +31,7 @@
 #define DG_STACK_DEPTH 512
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgAABBPolygonSoup::dgNodeBuilder: public dgAABBPolygonSoup::dgNode
 {
 	public:
@@ -132,7 +132,7 @@ class dgAABBPolygonSoup::dgNodeBuilder: public dgAABBPolygonSoup::dgNode
 	dgInt32 m_faceIndex;
 	dgInt32 m_indexCount;
 	const dgInt32* m_faceIndices;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 

--- a/sdk/dgCore/dgIntersections.h
+++ b/sdk/dgCore/dgIntersections.h
@@ -119,7 +119,7 @@ DG_INLINE dgFloat32 dgBoxDistanceToOrigin2 (const dgVector& minBox, const dgVect
 }
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgFastRayTest
 {
 	public:
@@ -224,10 +224,10 @@ class dgFastRayTest
 	dgVector m_maxT;
 	dgVector m_unitDir;
 	dgVector m_isParallel;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT 
+DG_MSC_VECTOR_ALIGNMENT 
 class dgFastAABBInfo: public dgObb
 {
 	public:
@@ -387,7 +387,7 @@ class dgFastAABBInfo: public dgObb
 	friend class dgAABBPolygonSoup;
 	friend class dgCollisionUserMesh;
 	friend class dgCollisionHeightField;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 #endif

--- a/sdk/dgCore/dgMatrix.h
+++ b/sdk/dgCore/dgMatrix.h
@@ -36,7 +36,7 @@ const dgMatrix& dgGetZeroMatrix ();
 const dgMatrix& dgGetIdentityMatrix();
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgMatrix
 {
 	public:
@@ -103,7 +103,7 @@ class dgMatrix
 
 	static dgMatrix m_zeroMatrix;
 	static dgMatrix m_identityMatrix;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 
@@ -322,7 +322,7 @@ DG_INLINE dgMatrix dgRollMatrix(dgFloat32 ang)
 
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgSpatialMatrix
 {
 	public:
@@ -373,7 +373,7 @@ class dgSpatialMatrix
 	}
 
 	dgSpatialVector m_rows[6];
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 #endif

--- a/sdk/dgCore/dgObb.h
+++ b/sdk/dgCore/dgObb.h
@@ -31,7 +31,7 @@
 
 class dgPlane;
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgObb: public dgMatrix
 {
 	public:
@@ -72,7 +72,7 @@ class dgObb: public dgMatrix
 
 	public:
 	dgVector m_size;
-} DG_GCC_VECTOR_ALIGMENT; 
+} DG_GCC_VECTOR_ALIGNMENT; 
 
 
 inline dgObb::dgObb (const dgQuaternion &quat, const dgVector &position, const dgVector& dim)

--- a/sdk/dgCore/dgPlane.h
+++ b/sdk/dgCore/dgPlane.h
@@ -30,7 +30,7 @@
 	#define dgPlane dgBigPlane
 #else 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgPlane: public dgVector
 {
 	public:
@@ -42,12 +42,12 @@ class dgPlane: public dgVector
 	dgPlane Scale (dgFloat32 s) const;
 	dgFloat32 Evalue (const dgFloat32* const point) const;
 	dgFloat32 Evalue (const dgVector &point) const;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 #endif
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgBigPlane: public dgBigVector
 {
 	public:
@@ -59,7 +59,7 @@ class dgBigPlane: public dgBigVector
 	dgBigPlane Scale (dgFloat64 s) const;
 	dgFloat64 Evalue (const dgFloat64* const point) const;
 	dgFloat64 Evalue (const dgBigVector &point) const;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 

--- a/sdk/dgCore/dgPolyhedra.h
+++ b/sdk/dgCore/dgPolyhedra.h
@@ -41,7 +41,7 @@ class dgVertexCollapseVertexMetric;
 typedef dgInt64 dgEdgeKey;
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgEdge
 {
 	public:
@@ -56,7 +56,7 @@ class dgEdge
 	dgEdge* m_prev;
 	dgEdge* m_twin;
 	dgInt32 m_mark;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 class dgPolyhedra: public dgTree <dgEdge, dgEdgeKey>

--- a/sdk/dgCore/dgQuaternion.h
+++ b/sdk/dgCore/dgQuaternion.h
@@ -27,7 +27,7 @@
 class dgVector;
 class dgMatrix;
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgQuaternion
 {
 	public:
@@ -55,7 +55,7 @@ class dgQuaternion
 	dgFloat32 m_y;
 	dgFloat32 m_z;
 	dgFloat32 m_w;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 DG_INLINE dgQuaternion::dgQuaternion()

--- a/sdk/dgCore/dgTypes.h
+++ b/sdk/dgCore/dgTypes.h
@@ -198,7 +198,7 @@
 #ifdef _DEBUG
 	#define DG_INLINE inline
 #else
-	#if (defined (_WIN_32_VER) || defined (_WIN_64_VER))
+	#if defined(_MSC_VER)
 			#define DG_INLINE __forceinline 
 	#else 
 		#define DG_INLINE	inline
@@ -210,20 +210,20 @@
 #define DG_VECTOR_SIMD_SIZE		16
 #define DG_VECTOR_AVX2_SIZE		32
 
-#if (defined (_WIN_32_VER) || defined (_WIN_64_VER))
-	#define	DG_GCC_VECTOR_ALIGMENT	
-	#define	DG_MSC_VECTOR_ALIGMENT			__declspec(align(DG_VECTOR_SIMD_SIZE))
+#if defined(_MSC_VER)
+	#define	DG_GCC_VECTOR_ALIGMENT
+	#define	DG_MSC_VECTOR_ALIGMENT    __declspec(align(DG_VECTOR_SIMD_SIZE))
 #else
-	#define	DG_GCC_VECTOR_ALIGMENT			__attribute__ ((aligned (DG_VECTOR_SIMD_SIZE)))
-	#define	DG_MSC_VECTOR_ALIGMENT			
+	#define	DG_GCC_VECTOR_ALIGMENT    __attribute__ ((aligned (DG_VECTOR_SIMD_SIZE)))
+	#define	DG_MSC_VECTOR_ALIGMENT
 #endif
 
-#if (defined (_WIN_32_VER) || defined (_WIN_64_VER))
-	#define	DG_GCC_AVX_ALIGMENT	
-	#define	DG_MSC_AVX_ALIGMENT			__declspec(align(DG_VECTOR_AVX2_SIZE))
+#if defined(_MSC_VER)
+	#define	DG_GCC_AVX_ALIGMENT
+	#define	DG_MSC_AVX_ALIGMENT       __declspec(align(DG_VECTOR_AVX2_SIZE))
 #else
-	#define	DG_GCC_AVX_ALIGMENT			__attribute__ ((aligned (DG_VECTOR_AVX2_SIZE)))
-	#define	DG_MSC_AVX_ALIGMENT			
+	#define	DG_GCC_AVX_ALIGMENT       __attribute__ ((aligned (DG_VECTOR_AVX2_SIZE)))
+	#define	DG_MSC_AVX_ALIGMENT
 #endif
 
 

--- a/sdk/dgCore/dgTypes.h
+++ b/sdk/dgCore/dgTypes.h
@@ -211,19 +211,19 @@
 #define DG_VECTOR_AVX2_SIZE		32
 
 #if defined(_MSC_VER)
-	#define	DG_GCC_VECTOR_ALIGMENT
-	#define	DG_MSC_VECTOR_ALIGMENT    __declspec(align(DG_VECTOR_SIMD_SIZE))
+	#define	DG_GCC_VECTOR_ALIGNMENT
+	#define	DG_MSC_VECTOR_ALIGNMENT    __declspec(align(DG_VECTOR_SIMD_SIZE))
 #else
-	#define	DG_GCC_VECTOR_ALIGMENT    __attribute__ ((aligned (DG_VECTOR_SIMD_SIZE)))
-	#define	DG_MSC_VECTOR_ALIGMENT
+	#define	DG_GCC_VECTOR_ALIGNMENT    __attribute__ ((aligned (DG_VECTOR_SIMD_SIZE)))
+	#define	DG_MSC_VECTOR_ALIGNMENT
 #endif
 
 #if defined(_MSC_VER)
-	#define	DG_GCC_AVX_ALIGMENT
-	#define	DG_MSC_AVX_ALIGMENT       __declspec(align(DG_VECTOR_AVX2_SIZE))
+	#define	DG_GCC_AVX_ALIGNMENT
+	#define	DG_MSC_AVX_ALIGNMENT       __declspec(align(DG_VECTOR_AVX2_SIZE))
 #else
-	#define	DG_GCC_AVX_ALIGMENT       __attribute__ ((aligned (DG_VECTOR_AVX2_SIZE)))
-	#define	DG_MSC_AVX_ALIGMENT
+	#define	DG_GCC_AVX_ALIGNMENT       __attribute__ ((aligned (DG_VECTOR_AVX2_SIZE)))
+	#define	DG_MSC_AVX_ALIGNMENT
 #endif
 
 

--- a/sdk/dgCore/dgVectorScalar.h
+++ b/sdk/dgCore/dgVectorScalar.h
@@ -34,7 +34,7 @@
 #else
 
 class dgBigVector;
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgVector
 {
 	public:
@@ -469,11 +469,11 @@ class dgVector
 	static dgVector m_epsilon;
 	static dgVector m_signMask;
 	static dgVector m_triplexMask;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 #endif
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgBigVector
 {
 	public:
@@ -903,10 +903,10 @@ class dgBigVector
 	static dgBigVector m_epsilon;
 	static dgBigVector m_signMask;
 	static dgBigVector m_triplexMask;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgSpatialVector
 {
 	public:
@@ -988,7 +988,7 @@ class dgSpatialVector
 
 	dgFloat64 m_d[6];
 	static dgSpatialVector m_zero;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 #endif
 #endif

--- a/sdk/dgCore/dgVectorSimd.h
+++ b/sdk/dgCore/dgVectorSimd.h
@@ -34,7 +34,7 @@ class dgBigVector;
 // 4 x 1 single precision SSE vector class declaration
 //
 // *****************************************************************************************
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgVector
 {
 	#define PERMUTE_MASK(w, z, y, x)		_MM_SHUFFLE (w, z, y, x)
@@ -440,7 +440,7 @@ class dgVector
 	static dgVector m_epsilon;
 	static dgVector m_signMask;
 	static dgVector m_triplexMask;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 #endif
 
 
@@ -449,7 +449,7 @@ class dgVector
 // 4 x 1 double precision SSE2 vector class declaration
 //
 // *****************************************************************************************
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgBigVector
 {
 	#define PERMUT_MASK_DOUBLE(y, x)	_MM_SHUFFLE2 (y, x)
@@ -881,10 +881,10 @@ class dgBigVector
 	static dgBigVector m_epsilon;
 	static dgBigVector m_signMask;
 	static dgBigVector m_triplexMask;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgSpatialVector
 {
 	public:
@@ -971,7 +971,7 @@ class dgSpatialVector
 	__m128d m_d1;
 	__m128d m_d2;
 	static dgSpatialVector m_zero;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 #endif
 #endif

--- a/sdk/dgNewtonAvx/dgSolver.h
+++ b/sdk/dgNewtonAvx/dgSolver.h
@@ -30,7 +30,7 @@
 #define DG_SOA_WORD_GROUP_SIZE	8 
 
 #ifdef _NEWTON_USE_DOUBLE
-	DG_MSC_AVX_ALIGMENT
+	DG_MSC_AVX_ALIGNMENT
 	class dgSoaFloat
 	{
 		public:
@@ -157,11 +157,11 @@
 
 		__m256d m_low;
 		__m256d m_high;
-	} DG_GCC_AVX_ALIGMENT;
+	} DG_GCC_AVX_ALIGNMENT;
 
 #else 
 
-	DG_MSC_AVX_ALIGMENT
+	DG_MSC_AVX_ALIGNMENT
 	class dgSoaFloat
 	{
 		public:
@@ -284,36 +284,36 @@
 		}
 
 		__m256 m_type;
-	} DG_GCC_AVX_ALIGMENT;
+	} DG_GCC_AVX_ALIGNMENT;
 #endif
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector3
 {
 	public:
 	dgSoaFloat m_x;
 	dgSoaFloat m_y;
 	dgSoaFloat m_z;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector6
 {
 	public:
 	dgSoaVector3 m_linear;
 	dgSoaVector3 m_angular;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaJacobianPair
 {
 	public:
 	dgSoaVector6 m_jacobianM0;
 	dgSoaVector6 m_jacobianM1;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaMatrixElement
 {
 	public:
@@ -327,9 +327,9 @@ class dgSoaMatrixElement
 	dgSoaFloat m_normalForceIndex;
 	dgSoaFloat m_lowerBoundFrictionCoefficent;
 	dgSoaFloat m_upperBoundFrictionCoefficent;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSolver: public dgParallelBodySolver
 {
 	public:
@@ -390,7 +390,7 @@ class dgSolver: public dgParallelBodySolver
 	dgVector m_zero;
 	dgVector m_negOne;
 	dgArray<dgSoaMatrixElement> m_massMatrix;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
 #endif

--- a/sdk/dgNewtonAvx2/dgSolver.h
+++ b/sdk/dgNewtonAvx2/dgSolver.h
@@ -28,7 +28,7 @@
 #define DG_SOA_WORD_GROUP_SIZE	8 
 
 #ifdef _NEWTON_USE_DOUBLE
-	DG_MSC_AVX_ALIGMENT
+	DG_MSC_AVX_ALIGNMENT
 	class dgSoaFloat
 	{
 		public:
@@ -159,10 +159,10 @@
 				__m256i m_highInt;
 			};
 		};
-	} DG_GCC_AVX_ALIGMENT;
+	} DG_GCC_AVX_ALIGNMENT;
 
 #else 
-	DG_MSC_AVX_ALIGMENT
+	DG_MSC_AVX_ALIGNMENT
 	class dgSoaFloat
 	{
 		public:
@@ -282,36 +282,36 @@
 			__m256 m_type;
 			__m256i m_typeInt;
 		};
-	} DG_GCC_AVX_ALIGMENT;
+	} DG_GCC_AVX_ALIGNMENT;
 #endif
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector3
 {
 	public:
 	dgSoaFloat m_x;
 	dgSoaFloat m_y;
 	dgSoaFloat m_z;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector6
 {
 	public:
 	dgSoaVector3 m_linear;
 	dgSoaVector3 m_angular;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaJacobianPair
 {
 	public:
 	dgSoaVector6 m_jacobianM0;
 	dgSoaVector6 m_jacobianM1;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaMatrixElement
 {
 	public:
@@ -325,9 +325,9 @@ class dgSoaMatrixElement
 	dgSoaFloat m_normalForceIndex;
 	dgSoaFloat m_lowerBoundFrictionCoefficent;
 	dgSoaFloat m_upperBoundFrictionCoefficent;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSolver: public dgParallelBodySolver
 {
 	public:
@@ -389,7 +389,7 @@ class dgSolver: public dgParallelBodySolver
 	dgVector m_zero;
 	dgVector m_negOne;
 	dgArray<dgSoaMatrixElement> m_massMatrix;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
 #endif

--- a/sdk/dgNewtonReferenceGPU/dgSolver.h
+++ b/sdk/dgNewtonReferenceGPU/dgSolver.h
@@ -28,7 +28,7 @@
 #define DG_SOA_WORD_GROUP_SIZE	8 
 
 #ifdef _NEWTON_USE_DOUBLE
-	DG_MSC_AVX_ALIGMENT
+	DG_MSC_AVX_ALIGNMENT
 	class dgSoaFloat
 	{
 		public:
@@ -159,10 +159,10 @@
 				__m256i m_highInt;
 			};
 		};
-	} DG_GCC_AVX_ALIGMENT;
+	} DG_GCC_AVX_ALIGNMENT;
 
 #else 
-	DG_MSC_AVX_ALIGMENT
+	DG_MSC_AVX_ALIGNMENT
 	class dgSoaFloat
 	{
 		public:
@@ -282,36 +282,36 @@
 			__m256 m_type;
 			__m256i m_typeInt;
 		};
-	} DG_GCC_AVX_ALIGMENT;
+	} DG_GCC_AVX_ALIGNMENT;
 #endif
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector3
 {
 	public:
 	dgSoaFloat m_x;
 	dgSoaFloat m_y;
 	dgSoaFloat m_z;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector6
 {
 	public:
 	dgSoaVector3 m_linear;
 	dgSoaVector3 m_angular;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaJacobianPair
 {
 	public:
 	dgSoaVector6 m_jacobianM0;
 	dgSoaVector6 m_jacobianM1;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaMatrixElement
 {
 	public:
@@ -325,9 +325,9 @@ class dgSoaMatrixElement
 	dgSoaFloat m_normalForceIndex;
 	dgSoaFloat m_lowerBoundFrictionCoefficent;
 	dgSoaFloat m_upperBoundFrictionCoefficent;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSolver: public dgParallelBodySolver
 {
 	public:
@@ -389,7 +389,7 @@ class dgSolver: public dgParallelBodySolver
 	dgVector m_zero;
 	dgVector m_negOne;
 	dgArray<dgSoaMatrixElement> m_massMatrix;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
 #endif

--- a/sdk/dgNewtonSse4.2/dgSolver.h
+++ b/sdk/dgNewtonSse4.2/dgSolver.h
@@ -29,7 +29,7 @@
 
 #define DG_SOA_WORD_GROUP_SIZE	8 
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaFloat
 {
 	public:
@@ -168,36 +168,36 @@ class dgSoaFloat
 
 	dgVector m_low;
 	dgVector m_high;
-}DG_GCC_AVX_ALIGMENT;
+}DG_GCC_AVX_ALIGNMENT;
 
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector3
 {
 	public:
 	dgSoaFloat m_x;
 	dgSoaFloat m_y;
 	dgSoaFloat m_z;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector6
 {
 	public:
 	dgSoaVector3 m_linear;
 	dgSoaVector3 m_angular;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaJacobianPair
 {
 	public:
 	dgSoaVector6 m_jacobianM0;
 	dgSoaVector6 m_jacobianM1;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaMatrixElement
 {
 	public:
@@ -211,9 +211,9 @@ class dgSoaMatrixElement
 	dgSoaFloat m_normalForceIndex;
 	dgSoaFloat m_lowerBoundFrictionCoefficent;
 	dgSoaFloat m_upperBoundFrictionCoefficent;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSolver: public dgParallelBodySolver
 {
 	public:
@@ -275,7 +275,7 @@ class dgSolver: public dgParallelBodySolver
 	dgVector m_zero;
 	dgVector m_negOne;
 	dgArray<dgSoaMatrixElement> m_massMatrix;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
 #endif

--- a/sdk/dgNewtonVulkan/dgSolver.h
+++ b/sdk/dgNewtonVulkan/dgSolver.h
@@ -30,7 +30,7 @@
 #define DG_SOA_WORD_GROUP_SIZE	8 
 
 #ifdef _NEWTON_USE_DOUBLE
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaFloat
 {
 	public:
@@ -159,7 +159,7 @@ class dgSoaFloat
 		dgInt64 m_i[DG_SOA_WORD_GROUP_SIZE];
 		dgFloat32 m_f[DG_SOA_WORD_GROUP_SIZE];
 	};
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 #else 
 
@@ -279,37 +279,37 @@ class dgSoaFloat
 		dgInt32 m_i[DG_SOA_WORD_GROUP_SIZE];
 		dgFloat32 m_f[DG_SOA_WORD_GROUP_SIZE];
 	};
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 #endif
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector3
 {
 	public:
 	dgSoaFloat m_x;
 	dgSoaFloat m_y;
 	dgSoaFloat m_z;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaVector6
 {
 	public:
 	dgSoaVector3 m_linear;
 	dgSoaVector3 m_angular;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaJacobianPair
 {
 	public:
 	dgSoaVector6 m_jacobianM0;
 	dgSoaVector6 m_jacobianM1;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSoaMatrixElement
 {
 	public:
@@ -323,7 +323,7 @@ class dgSoaMatrixElement
 	dgSoaFloat m_normalForceIndex;
 	dgSoaFloat m_lowerBoundFrictionCoefficent;
 	dgSoaFloat m_upperBoundFrictionCoefficent;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 
 
@@ -397,7 +397,7 @@ class dgGpuBody
 };
 
 
-DG_MSC_AVX_ALIGMENT
+DG_MSC_AVX_ALIGNMENT
 class dgSolver: public dgParallelBodySolver
 {
 	public:
@@ -475,6 +475,6 @@ class dgSolver: public dgParallelBodySolver
 
 	dgRowPair* m_bilateralPairs;
 	dgInt32 m_bilateralRowsCount;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
 #endif

--- a/sdk/dgPhysics/dgBody.h
+++ b/sdk/dgPhysics/dgBody.h
@@ -44,17 +44,17 @@ class dgBroadPhaseAggregate;
 
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 struct dgLineBox
 {
 	dgVector m_l0;
 	dgVector m_l1;
 	dgVector m_boxL0;
 	dgVector m_boxL1;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgBody  
 {
 	public:
@@ -337,7 +337,7 @@ class dgBody
 	friend class dgCollidingPairCollector;
 	friend class dgCollisionLumpedMassParticles;
 
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 // *****************************************************************************
 // 

--- a/sdk/dgPhysics/dgBroadPhase.h
+++ b/sdk/dgPhysics/dgBroadPhase.h
@@ -51,7 +51,7 @@ class dgConvexCastReturnInfo
 };
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgBroadPhaseNode
 {
 	public:
@@ -126,7 +126,7 @@ class dgBroadPhaseNode
 
 	static dgVector m_broadPhaseScale;
 	static dgVector m_broadInvPhaseScale;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 class dgBroadPhaseBodyNode: public dgBroadPhaseNode
@@ -222,7 +222,7 @@ class dgBroadPhaseTreeNode: public dgBroadPhaseNode
 	dgBroadPhaseNode* m_left;
 	dgBroadPhaseNode* m_right;
 	dgList<dgBroadPhaseTreeNode*>::dgListNode* m_fitnessNode;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 #define DG_CONTACT_CACHE_LINE_SIZE 4
 

--- a/sdk/dgPhysics/dgCollision.h
+++ b/sdk/dgPhysics/dgCollision.h
@@ -75,7 +75,7 @@ enum dgCollisionID
 };
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgCollisionInfo
 {
 	public:
@@ -208,9 +208,9 @@ class dgCollisionInfo
 		dgSceneData m_sceneCollision;
 		dgFloat32 m_paramArray[32];
 	};
-}DG_GCC_VECTOR_ALIGMENT;
+}DG_GCC_VECTOR_ALIGNMENT;
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgCollision
 {
 	public:
@@ -318,7 +318,7 @@ class dgCollision
 	friend class dgMinkowskiConv;
 	friend class dgCollisionInstance;
 	friend class dgCollisionCompound;
-}DG_GCC_VECTOR_ALIGMENT;
+}DG_GCC_VECTOR_ALIGNMENT;
 
 DG_INLINE dgCollisionID dgCollision::GetCollisionPrimityType () const
 {

--- a/sdk/dgPhysics/dgCollisionBVH.h
+++ b/sdk/dgPhysics/dgCollisionBVH.h
@@ -32,7 +32,7 @@ typedef dgFloat32 (*dgCollisionBVHUserRayCastCallback) (const dgBody* const body
 class dgCollisionBVH: public dgCollisionMesh, public dgAABBPolygonSoup
 {
 	public:
-	DG_MSC_VECTOR_ALIGMENT 
+	DG_MSC_VECTOR_ALIGNMENT 
 	class dgBVHRay: public dgFastRayTest 
 	{
 		public:
@@ -48,7 +48,7 @@ class dgCollisionBVH: public dgCollisionMesh, public dgAABBPolygonSoup
 		void* m_userData;
 		const dgBody* m_myBody;
 		const dgCollisionBVH* m_me;
-	} DG_GCC_VECTOR_ALIGMENT;
+	} DG_GCC_VECTOR_ALIGNMENT;
 
 	dgCollisionBVH(dgWorld* const world);
 	dgCollisionBVH (dgWorld* const world, dgDeserialize deserialization, void* const userData, dgInt32 revisionNumber);

--- a/sdk/dgPhysics/dgCollisionCompound.h
+++ b/sdk/dgPhysics/dgCollisionCompound.h
@@ -51,7 +51,7 @@ class dgCollisionCompound: public dgCollision
 		void AddNode (dgNodeBase* const node, dgInt32 index, const dgCollisionInstance* const parent); 
 	};
 
-	DG_MSC_VECTOR_ALIGMENT
+	DG_MSC_VECTOR_ALIGNMENT
 	class dgOOBBTestData
 	{
 		public:
@@ -76,10 +76,10 @@ class dgCollisionCompound: public dgCollision
 		dgVector m_extendsMaxX[3];
 		mutable dgFloat32 m_separatingDistance;
 		static dgVector m_maxDist;
-	} DG_GCC_VECTOR_ALIGMENT;
+	} DG_GCC_VECTOR_ALIGNMENT;
 
 
-	DG_MSC_VECTOR_ALIGMENT
+	DG_MSC_VECTOR_ALIGNMENT
 	class dgNodeBase
 	{
 		public:
@@ -119,7 +119,7 @@ class dgCollisionCompound: public dgCollision
 		dgNodeBase* m_parent;
 		dgCollisionInstance* m_shape;
 		dgTreeArray::dgTreeNode* m_myNode; 
-	} DG_GCC_VECTOR_ALIGMENT;
+	} DG_GCC_VECTOR_ALIGNMENT;
 
 	protected:
 	class dgNodePairs

--- a/sdk/dgPhysics/dgCollisionConvex.h
+++ b/sdk/dgPhysics/dgCollisionConvex.h
@@ -29,7 +29,7 @@
 #define D_MIN_CONVEX_SHAPE_SIZE			dgFloat32 (1.0f/128.0f)
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgCollisionConvex: public dgCollision
 {
 	public:
@@ -103,7 +103,7 @@ class dgCollisionConvex: public dgCollision
 	friend class dgMinkowskiConv;
 	friend class dgCollisionCompound;
 	friend class dgCollisionConvexModifier;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 

--- a/sdk/dgPhysics/dgCollisionConvexHull.cpp
+++ b/sdk/dgPhysics/dgCollisionConvexHull.cpp
@@ -33,7 +33,7 @@
 
 #define DG_CONVEX_VERTEX_CHUNK_SIZE	4
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgCollisionConvexHull::dgConvexBox
 {
 	public:
@@ -42,7 +42,7 @@ class dgCollisionConvexHull::dgConvexBox
 	dgInt32 m_vertexCount;
 	dgInt32 m_leftBox;
 	dgInt32 m_rightBox;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 dgCollisionConvexHull::dgCollisionConvexHull(dgMemoryAllocator* const allocator, dgUnsigned32 signature)
 	:dgCollisionConvex(allocator, signature, m_convexHullCollision)

--- a/sdk/dgPhysics/dgCollisionConvexPolygon.h
+++ b/sdk/dgPhysics/dgCollisionConvexPolygon.h
@@ -27,7 +27,7 @@
 
 #define DG_CONVEX_POLYGON_MAX_VERTEX_COUNT	64
 
-DG_MSC_VECTOR_ALIGMENT 
+DG_MSC_VECTOR_ALIGNMENT 
 class dgCollisionConvexPolygon: public dgCollisionConvex	
 {
 	public:
@@ -74,6 +74,6 @@ class dgCollisionConvexPolygon: public dgCollisionConvex
 	const dgFloat32* m_vertex;
 	const dgInt32* m_vertexIndex;
 	const dgInt32* m_adjacentFaceEdgeNormalIndex;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 #endif

--- a/sdk/dgPhysics/dgCollisionMesh.h
+++ b/sdk/dgPhysics/dgCollisionMesh.h
@@ -37,7 +37,7 @@ typedef void (*dgCollisionMeshCollisionCallback) (const dgBody* const bodyWithTr
 												  dgInt32 vertexCount, const dgFloat32* const vertex, dgInt32 vertexStrideInBytes); 
 
 
-DG_MSC_VECTOR_ALIGMENT 
+DG_MSC_VECTOR_ALIGNMENT 
 class dgPolygonMeshDesc: public dgFastAABBInfo
 {
 	public:
@@ -127,9 +127,9 @@ class dgPolygonMeshDesc: public dgFastAABBInfo
 	bool m_doContinuesCollisionTest;
 	dgInt32 m_globalFaceVertexIndex[DG_MAX_COLLIDING_INDICES];
 	dgMesh m_meshData;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
-DG_MSC_VECTOR_ALIGMENT 
+DG_MSC_VECTOR_ALIGNMENT 
 class dgCollisionMeshRayHitDesc
 {
 	public:
@@ -145,7 +145,7 @@ class dgCollisionMeshRayHitDesc
 	void*  m_userData;
 	void*  m_altenateUserData;
 	dgMatrix m_matrix;
-}DG_GCC_VECTOR_ALIGMENT;
+}DG_GCC_VECTOR_ALIGNMENT;
 
 
 
@@ -153,7 +153,7 @@ class dgCollisionMesh: public dgCollision
 {
 	public:
 
-	DG_MSC_VECTOR_ALIGMENT 
+	DG_MSC_VECTOR_ALIGNMENT 
 	class dgMeshVertexListIndexList
 	{
 		public:
@@ -164,7 +164,7 @@ class dgCollisionMesh: public dgCollision
 		dgInt32 m_maxIndexCount;
 		dgInt32 m_vertexCount;
 		dgInt32 m_vertexStrideInBytes;
-	}DG_GCC_VECTOR_ALIGMENT;
+	}DG_GCC_VECTOR_ALIGNMENT;
 
 
 	dgCollisionMesh (dgWorld* const world, dgCollisionID type);

--- a/sdk/dgPhysics/dgConstraint.h
+++ b/sdk/dgPhysics/dgConstraint.h
@@ -80,21 +80,21 @@ class dgBilateralBounds
 	dgInt32 m_normalIndex;
 };
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgJacobian
 {
 	public:
 	dgVector m_linear;
 	dgVector m_angular;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgJacobianPair
 {
 	public:
 	dgJacobian m_jacobianM0;
 	dgJacobian m_jacobianM1;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 class dgLeftHandSide;
 class dgRightHandSide;
@@ -110,7 +110,7 @@ class dgJointAccelerationDecriptor
 	const dgLeftHandSide* m_leftHandSide;
 };
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgContraintDescritor
 {
 	public:
@@ -127,12 +127,12 @@ class dgContraintDescritor
 	dgInt32 m_threadIndex;
 	dgFloat32 m_timestep;
 	dgFloat32 m_invTimestep;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 typedef void (dgApi *OnConstraintDestroy) (dgConstraint& me);
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgConstraint
 {
 	public:
@@ -239,7 +239,7 @@ class dgConstraint
 	friend class dgParallelSolverInitFeedbackUpdate;
 	friend class dgParallelSolverBuildJacobianMatrix;
 	friend class dgBroadPhaseMaterialCallbackWorkerThread;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 DG_INLINE dgConstraint::dgConstraint() 
 	:m_userData(NULL)

--- a/sdk/dgPhysics/dgContact.h
+++ b/sdk/dgPhysics/dgContact.h
@@ -66,7 +66,7 @@ class dgContactList: public dgArray<dgContact*>
 	dgInt32 m_activeContactCount;
 };
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgCollisionParamProxy
 {	
 	public:
@@ -101,10 +101,10 @@ class dgCollisionParamProxy
 	bool m_continueCollision;
 	bool m_intersectionTestOnly;
 
-}DG_GCC_VECTOR_ALIGMENT;
+}DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgContactPoint
 {
 	public:
@@ -117,10 +117,10 @@ class dgContactPoint
 	dgInt64 m_shapeId0;
 	dgInt64 m_shapeId1;
 	dgFloat32 m_penetration;
-}DG_GCC_VECTOR_ALIGMENT;
+}DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT 
+DG_MSC_VECTOR_ALIGNMENT 
 class dgContactMaterial: public dgContactPoint
 {
 	public:
@@ -138,7 +138,7 @@ class dgContactMaterial: public dgContactPoint
 		m_resetSkeletonIntraCollision = 1<<10,
 	};
 
-	DG_MSC_VECTOR_ALIGMENT 
+	DG_MSC_VECTOR_ALIGNMENT 
 	class dgUserContactPoint
 	{
 		public:
@@ -148,7 +148,7 @@ class dgContactMaterial: public dgContactPoint
 		dgUnsigned64 m_shapeId1;
 		dgFloat32 m_penetration;
 		dgUnsigned32 m_unused[3];
-	} DG_GCC_VECTOR_ALIGMENT;
+	} DG_GCC_VECTOR_ALIGNMENT;
 
 	typedef bool (dgApi *OnAABBOverlap) (dgContact& contactJoint, dgFloat32 timestep, dgInt32 threadIndex);
 	typedef void (dgApi *OnContactCallback) (dgContact& contactJoint, dgFloat32 timestep, dgInt32 threadIndex);
@@ -193,10 +193,10 @@ class dgContactMaterial: public dgContactPoint
 	friend class dgCollidingPairCollector;
 	friend class dgBroadPhaseMaterialCallbackWorkerThread;
 	
-}DG_GCC_VECTOR_ALIGMENT;
+}DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT 
+DG_MSC_VECTOR_ALIGNMENT 
 class dgContact: public dgConstraint, public dgList<dgContactMaterial>
 {
 	public:
@@ -265,7 +265,7 @@ class dgContact: public dgConstraint, public dgList<dgContactMaterial>
 	friend class dgCollisionConvexPolygon;
 	friend class dgCollidingPairCollector;
 	
-}DG_GCC_VECTOR_ALIGMENT;
+}DG_GCC_VECTOR_ALIGNMENT;
 
 DG_INLINE void dgContactMaterial::SetCollisionCallback (OnAABBOverlap aabbOverlap, OnContactCallback contact) 
 {

--- a/sdk/dgPhysics/dgContactSolver.h
+++ b/sdk/dgPhysics/dgContactSolver.h
@@ -25,7 +25,7 @@
 #include "dgCollision.h"
 #include "dgCollisionInstance.h"
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgMinkFace
 {
 	public:
@@ -34,7 +34,7 @@ class dgMinkFace
 	dgInt16 m_vertex[3];
 	dgInt8 m_mark;
 	dgInt8 m_alive;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 #define DG_SEPARATION_PLANES_ITERATIONS	8
 #define DG_CONVEX_MINK_STACK_SIZE		64
@@ -49,7 +49,7 @@ class dgMinkFace
 
 class dgCollisionParamProxy;
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgContactSolver: public dgDownHeap<dgMinkFace *, dgFloat32>  
 {
 	public: 
@@ -124,7 +124,7 @@ class dgContactSolver: public dgDownHeap<dgMinkFace *, dgFloat32>
 
 	static dgVector m_hullDirs[14]; 
 	static dgInt32 m_rayCastSimplex[4][4];
-}DG_GCC_VECTOR_ALIGMENT;
+}DG_GCC_VECTOR_ALIGNMENT;
 
 
 #endif 

--- a/sdk/dgPhysics/dgDynamicBody.h
+++ b/sdk/dgPhysics/dgDynamicBody.h
@@ -41,7 +41,7 @@
 
 class dgSkeletonContainer;
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgDynamicBody : public dgBody 
 {
 	public:
@@ -118,10 +118,10 @@ class dgDynamicBody : public dgBody
 	friend class dgCollisionDeformableMesh;
 	friend class dgCollisionDeformableSolidMesh;
 	friend class dgCollisionMassSpringDamperSystem;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgDynamicBodyAsymetric: public dgDynamicBody
 {
 	public:
@@ -137,7 +137,7 @@ class dgDynamicBodyAsymetric: public dgDynamicBody
 	virtual void IntegrateOpenLoopExternalForce(dgFloat32 timestep);
 
 	dgMatrix m_principalAxis;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 

--- a/sdk/dgPhysics/dgKinematicBody.h
+++ b/sdk/dgPhysics/dgKinematicBody.h
@@ -26,7 +26,7 @@
 #include "dgBody.h"
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgKinematicBody: public dgBody 
 {
 	public:
@@ -63,7 +63,7 @@ class dgKinematicBody: public dgBody
 	friend class dgWorld;
 	friend class dgBroadPhase;
 	friend class dgWorldDynamicUpdate;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 

--- a/sdk/dgPhysics/dgNarrowPhaseCollision.cpp
+++ b/sdk/dgPhysics/dgNarrowPhaseCollision.cpp
@@ -51,7 +51,7 @@
 #include "dgCollisionIncompressibleParticles.h"
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgCollisionContactCloud: public dgCollisionConvex
 {
 	public:
@@ -126,7 +126,7 @@ class dgCollisionContactCloud: public dgCollisionConvex
 	static dgVector m_pruneUpDir;
 	static dgVector m_pruneSupportX;
 
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 dgVector dgCollisionContactCloud::m_pruneUpDir(dgFloat32(0.0f), dgFloat32(0.0f), dgFloat32(1.0f), dgFloat32(0.0f));
 dgVector dgCollisionContactCloud::m_pruneSupportX(dgFloat32(1.0f), dgFloat32(0.0f), dgFloat32(0.0f), dgFloat32(0.0f));

--- a/sdk/dgPhysics/dgSkeletonContainer.cpp
+++ b/sdk/dgPhysics/dgSkeletonContainer.cpp
@@ -37,29 +37,29 @@ class dgSkeletonContainer::dgNodePair
 	dgInt32 m_m1;
 };
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgSkeletonContainer::dgForcePair
 {
 	public:
 	dgSpatialVector m_joint;
 	dgSpatialVector m_body;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
-DG_MSC_VECTOR_ALIGMENT 
+DG_MSC_VECTOR_ALIGNMENT 
 class dgSkeletonContainer::dgMatriData
 {
 	public:
 	dgSpatialMatrix m_jt;
 	dgSpatialMatrix m_invMass;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
-DG_MSC_VECTOR_ALIGMENT 
+DG_MSC_VECTOR_ALIGNMENT 
 class dgSkeletonContainer::dgBodyJointMatrixDataPair
 {
 	public:
 	dgMatriData m_body;
 	dgMatriData m_joint;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 class dgSkeletonContainer::dgNode

--- a/sdk/dgPhysics/dgWorld.h
+++ b/sdk/dgPhysics/dgWorld.h
@@ -138,7 +138,7 @@ class dgDeadBodies: public dgTree<dgBody*, void* >
 
 typedef void (*OnPostUpdateCallback) (const dgWorld* const world, dgFloat32 timestep);
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgWorld
 	:public dgBodyMasterList
 	,public dgBodyMaterialList
@@ -547,7 +547,7 @@ class dgWorld
 	
 	friend class dgBroadPhaseMaterialCallbackWorkerThread;
 	friend class dgBroadPhaseCalculateContactsWorkerThread;
-} DG_GCC_VECTOR_ALIGMENT ;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
 inline dgMemoryAllocator* dgWorld::GetAllocator() const

--- a/sdk/dgPhysics/dgWorldDynamicUpdate.h
+++ b/sdk/dgPhysics/dgWorldDynamicUpdate.h
@@ -180,16 +180,16 @@ class dgQueue
 	T* m_pool;
 };
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgLeftHandSide
 {
 	public:
 	dgJacobianPair m_Jt;
 	dgJacobianPair m_JMinv;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgRightHandSide
 {
 	public:
@@ -210,7 +210,7 @@ class dgRightHandSide
 
 	dgForceImpactPair* m_jointFeebackForce;
 	dgInt32 m_normalForceIndex;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 class dgJacobianMemory
 {

--- a/sdk/dgPhysics/dgWorldDynamicsParallelSolver.h
+++ b/sdk/dgPhysics/dgWorldDynamicsParallelSolver.h
@@ -31,7 +31,7 @@ class dgSkeletonContainer;
 
 #define DG_WORK_GROUP_SIZE	8 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgWorkGroupFloat
 {
 	public:
@@ -150,35 +150,35 @@ class dgWorkGroupFloat
 
 	dgVector m_low;
 	dgVector m_high;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgWorkGroupVector3
 {
 	public:
 	dgWorkGroupFloat m_x;
 	dgWorkGroupFloat m_y;
 	dgWorkGroupFloat m_z;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgWorkGroupVector6
 {
 	public:
 	dgWorkGroupVector3 m_linear;
 	dgWorkGroupVector3 m_angular;
-} DG_GCC_AVX_ALIGMENT;
+} DG_GCC_AVX_ALIGNMENT;
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgSolverSoaJacobianPair
 {
 	public:
 	dgWorkGroupVector6 m_jacobianM0;
 	dgWorkGroupVector6 m_jacobianM1;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
-DG_MSC_VECTOR_ALIGMENT
+DG_MSC_VECTOR_ALIGNMENT
 class dgSolverSoaElement
 {
 	public:
@@ -192,7 +192,7 @@ class dgSolverSoaElement
 	dgWorkGroupFloat m_normalForceIndex;
 	dgWorkGroupFloat m_lowerBoundFrictionCoefficent;
 	dgWorkGroupFloat m_upperBoundFrictionCoefficent;
-} DG_GCC_VECTOR_ALIGMENT;
+} DG_GCC_VECTOR_ALIGNMENT;
 
 class dgParallelBodySolver
 {


### PR DESCRIPTION
Gets rid of warnings when compiling with MinGW