### PR TITLE
Fixes for cross compiling to Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,6 @@
 
 cmake_minimum_required(VERSION 3.4.0)
 
-
-option("NEWTON_WIN32CC" "Cross compile to 32 bit Windows" OFF)
-option("NEWTON_ARM32" "Cross compile to 32 bit Armv7-A" OFF)
-option("NEWTON_ARM64" "Cross compile to 64 bit Armv8-A" OFF)
 option("NEWTON_BUILD_SANDBOX_DEMOS" "generates demos projects" "ON")
 option("NEWTON_BUILD_PROFILER" "build profiler" OFF)
 option("NEWTON_BUILD_SINGLE_THREADED" "multi threaded" OFF)
@@ -33,108 +29,9 @@ set(CMAKE_DEBUG_POSTFIX "_d")
 
 project(NewtonSDK)
 
-message("NEWTON_WIN32CC is ${NEWTON_WIN32CC}")
-message("NEWTON_ARM32 is ${NEWTON_ARM32}")
-message("NEWTON_ARM64 is ${NEWTON_ARM64}")
-
 # determine if we are compiling for a 32bit or 64bit system
 include(CheckTypeSize)
 CHECK_TYPE_SIZE("void*" PTR_SIZE BUILTIN_TYPES_ONLY)
-
-if (NEWTON_WIN32CC STREQUAL "ON")
-	
-	message("Cross compiling to 32 bit windows")
-	
-	# todo:
-	# SET(CMAKE_SYSTEM_PROCESSOR arm)
-	
-	# specify the cross compiler
-	set(CMAKE_CROSSCOMPILING "ON")
-	
-	# 32 bit windows
-	SET(CMAKE_C_COMPILER i686-w64-mingw32-g++)
-	SET(CMAKE_CXX_COMPILER i686-w64-mingw32-g++)
-	SET(CMAKE_ASM_COMPILER i686-w64-mingw32-g++)
-	
-	SET(PTR_SIZE 4)
-	
-	set(NEWTON_ARM32 OFF FORCE)
-	set(NEWTON_ARM64 OFF FORCE)
-	
-	# needed to convince code that we are building win32
-	add_definitions(-D_WIN_32_VER)
-	add_definitions(-D_MINGW_32_VER)
-	
-	# need this as otherwise dgtypes won't cross compile
-	# DO WE REALLY NEED THIS?
-	
-	#add_definitions(-DDG_USE_THREAD_EMULATION)
-	
-	# todo: use NEWTON_STATIC_RUNTIME_LIBRARIES ?
-	# link statically - no libstdc dll dependancies
-	add_compile_options(-static)
-	
-	add_compile_options(-gdwarf-2)
-	
-	set(NEWTON_GENERATE_DLL "ON" FORCE)
-	
-	SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -static" )
-	SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -static" )
-	
-endif ()
-
-# cross compiling to arm forces variables to trigger arm via cross compiler:
-
-if (NEWTON_ARM32 STREQUAL "ON")
-	
-	message("Cross compiling to 32 bit arm linux")
-	
-	# specify the cross compiler
-	set(CMAKE_CROSSCOMPILING TRUE)
-	
-	SET(PTR_SIZE 4)
-	
-	# 32 bit arm # 32 bit arm / ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV)
-	SET(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
-	SET(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
-	SET(CMAKE_ASM_COMPILER arm-linux-gnueabihf-gcc)
-	SET(CMAKE_SYSTEM_PROCESSOR arm)
-	# this is needed for arm
-	add_definitions(-DDG_SCALAR_VECTOR_CLASS)
-	
-endif ()
-
-if (NEWTON_ARM64 STREQUAL "ON")
-	
-	message("Cross compiling to 64 bit arm linux")
-	
-	# specify the cross compiler
-	set(CMAKE_CROSSCOMPILING TRUE)
-	
-	# 64 bit arm # 64-bit LSB shared object, ARM aarch64, version 1 (SYSV)
-	SET(CMAKE_C_COMPILER   aarch64-linux-gnu-gcc)
-	SET(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
-	SET(CMAKE_ASM_COMPILER aarch64-linux-gnu-gcc)
-	SET(CMAKE_SYSTEM_PROCESSOR aarch64)
-	# this is needed for arm
-	add_definitions(-DDG_SCALAR_VECTOR_CLASS)
-endif ()
-
-message("CMAKE_SYSTEM_PROCESSOR is ${CMAKE_SYSTEM_PROCESSOR}")
-
-# enable 32 / 64 defines so that x86-only stuff is properly disabled
-
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
-	set(NEWTON_ARM32 ON)
-	# no vector class for arm32
-	add_definitions(-DDG_SCALAR_VECTOR_CLASS)
-endif()
-
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)")
-	set(NEWTON_ARM64 ON)
-	# no vector class for arm64
-	add_definitions(-DDG_SCALAR_VECTOR_CLASS)
-endif()
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -142,13 +39,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-if (NEWTON_DOUBLE_PRECISION)
+if(NEWTON_DOUBLE_PRECISION)
 	add_definitions(-D_NEWTON_USE_DOUBLE)
-endif ()
+endif()
 
-if (NEWTON_BUILD_SINGLE_THREADED)
+if(NEWTON_BUILD_SINGLE_THREADED)
 	add_definitions(-DDG_USE_THREAD_EMULATION)
-endif ()
+endif()
 
 #If no build type set, Release as default
 if(NOT CMAKE_BUILD_TYPE)
@@ -158,79 +55,54 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 if (PTR_SIZE EQUAL 8)
-  set(BUILD_64 TRUE)
-  message("64 bit build")
+	set(BUILD_64 TRUE)
 else ()
-  set(BUILD_64 FALSE)
-  message("32 bit build")
+	set(BUILD_64 FALSE)
 endif ()
 
 #check for MAC
 if(APPLE)
-  add_definitions(-D_MACOSX_VER)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-extensions")
+	add_definitions(-D_MACOSX_VER)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-extensions")
 endif(APPLE)
 
 #check for UNIX
-if (UNIX)
-    if (BUILD_64)
-      add_definitions(-D_POSIX_VER_64)
-    else (BUILD_64)
-      add_definitions(-D_POSIX_VER)
-    endif (BUILD_64)
+if(UNIX)
+	if (BUILD_64)
+		add_definitions(-D_POSIX_VER_64)
+	else (BUILD_64)
+		add_definitions(-D_POSIX_VER)
+	endif (BUILD_64)
 
-    include("GNUInstallDirs")
+	include("GNUInstallDirs")
 
-    # uninstall target
-    if(NOT TARGET uninstall)
-        configure_file(
-            "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-            "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-            IMMEDIATE @ONLY)
+	# uninstall target
+	if(NOT TARGET uninstall)
+		configure_file(
+			"${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+			"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+			IMMEDIATE @ONLY)
 
-        add_custom_target(uninstall
-            COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-    endif()
+		add_custom_target(uninstall
+			COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+	endif()
 
-    if (NEWTON_ARM64 STREQUAL "ON")
-	#message("NEWTON_ARM64 is ${NEWTON_ARM64}")
-	# arm64 specific extensions?
-    elseif(NEWTON_ARM32 STREQUAL "ON")
-	#message("NEWTON_ARM32 is ${NEWTON_ARM32}")
-	# arm32 specific extensions?
-    else()
-	# extensions for x86 variants
-	message ("With SSE3")
-    	add_compile_options(-msse3)
-    endif()
+	if(NOT ANDROID)
+		add_compile_options(-msse3)
+	endif()
+	add_compile_options(-fpermissive)
 
-    add_compile_options(-fpermissive)
-    #add_compile_options(-Wignored-attributes)
-    # no warnings
-    #add_compile_options(-w)
-
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
-
-    if (NOT NEWTON_WIN32CC STREQUAL "ON")
-	message ("DLL OFF")
-	set(NEWTON_GENERATE_DLL OFF CACHE BOOL "" FORCE)
-    endif()
-
-    set(NEWTON_STATIC_RUNTIME_LIBRARIES OFF CACHE BOOL "" FORCE)
-    set(NEWTON_BUILD_PROFILER OFF CACHE BOOL "" FORCE)
-
+	set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
 elseif (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "build" CACHE PATH "" FORCE)
+	set(CMAKE_INSTALL_PREFIX "build" CACHE PATH "" FORCE)
 endif ()
 
 if (MSVC)
-	message ("build visual studio projects")
-
 	if(NEWTON_STATIC_RUNTIME_LIBRARIES)
 		message ("link to static runtime libraries")
 		set(CMAKE_C_FLAGS_DEBUG "/MTd")
-                set(CMAKE_C_FLAGS_RELWITHDEBINFO "/MT")
+		set(CMAKE_C_FLAGS_RELWITHDEBINFO "/MT")
 		set(CMAKE_C_FLAGS_RELEASE "/MT")
 		set(CMAKE_CXX_FLAGS_DEBUG "/MTd")
 		set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MT")

--- a/sdk/dContainers/dContainersStdAfx.h
+++ b/sdk/dContainers/dContainersStdAfx.h
@@ -29,9 +29,17 @@
 
 #ifdef _DCONTAINERS_DLL
 	#ifdef _DCONTAINERS_EXPORT
-		#define DCONTAINERS_API __declspec (dllexport)
+		#if defined(_WIN32)
+			#define DCONTAINERS_API __declspec (dllexport)
+		#else
+			#define DCONTAINERS_API __attribute__((visibility("default")))
+		#endif
 	#else
-		#define DCONTAINERS_API __declspec (dllimport)
+		#if defined(_WIN32)
+			#define DCONTAINERS_API __declspec (dllimport)
+		#else
+			#define DCONTAINERS_API
+		#endif
 	#endif
 #else
 	#define DCONTAINERS_API


### PR DESCRIPTION
Seems to compile nicely for Android, I'll try to test later. I cleaned
up CMakeLists.txt, because all cross compilation related stuff should be
kept away from there and a separate CMake toolchain file should be used
instead to specify your compiler and target platform. Android-NDK
provides its own CMake toolchain file which I used to test the
build.