### PR TITLE
dFloatExceptions::m_mask is not defined.

### DIFF
--- a/newton-4.00/sdk/dCore/dUtils.h
+++ b/newton-4.00/sdk/dCore/dUtils.h
@@ -212,7 +212,8 @@ class dFloatExceptions
 
 	private:
 	//#if (defined (_MSC_VER) && defined (_WIN_32_VER))
-	#if defined (_MSC_VER)
+	//#if defined (_MSC_VER)
+    #if (defined(WIN32) || defined(_WIN32))
 		dUnsigned32 m_mask;
 	#endif
 };


### PR DESCRIPTION
This is because the macro guard in the header contains a different condition than the one from the source.

In .cpp file it checks for
```cpp
#if (defined(WIN32) || defined(_WIN32))
```
And in .h file it checks for:
```cpp
#if defined (_MSC_VER)
```
Which is not the case everywhere.