### PR TITLE
Allow building without AVX.

### DIFF
--- a/newton-4.00/sdk/CMakeLists.txt
+++ b/newton-4.00/sdk/CMakeLists.txt
@@ -84,11 +84,17 @@ else()
 		dNewton/dModels/dCharacter/*.h
 		dNewton/dModels/dCharacter/*.cpp)
 
-	if(MSVC)
-		 set_source_files_properties(dNewton/ndDynamicsUpdateAvx2.cpp PROPERTIES COMPILE_FLAGS " /arch:AVX2 " )
+	# exclude AVX files when disabled
+	if(NOT NEWTON_ENABLE_AVX)
+		list(FILTER HEADERS EXCLUDE REGEX "(Avx)")
+		list(FILTER CPP_SOURCE EXCLUDE REGEX "(Avx)")
+	endif()
+
+	if(MSVC AND NEWTON_ENABLE_AVX)
+		set_source_files_properties(dNewton/ndDynamicsUpdateAvx2.cpp PROPERTIES COMPILE_FLAGS " /arch:AVX2 " )
 	endif(MSVC)
 
-	if(UNIX)
+	if(UNIX AND NEWTON_ENABLE_AVX)
 		set_source_files_properties(dNewton/ndDynamicsUpdateAvx2.cpp PROPERTIES COMPILE_FLAGS " -march=haswell " )
 	endif(UNIX)
 

--- a/newton-4.00/sdk/dNewton/CMakeLists.txt
+++ b/newton-4.00/sdk/dNewton/CMakeLists.txt
@@ -32,6 +32,12 @@ file(GLOB HEADERS *.h dJoints/*.h)
 file(GLOB HEADERS *.h dModels/*.h)
 file(GLOB HEADERS *.h dModels/dVehicle/*.h)
 
+# exclude AVX files when disabled
+if(NOT NEWTON_ENABLE_AVX)
+	list(FILTER HEADERS EXCLUDE REGEX "(Avx)")
+	list(FILTER CPP_SOURCE EXCLUDE REGEX "(Avx)")
+endif()
+
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/" FILES ${CPP_SOURCE})
 
 include_directories(./)

--- a/newton-4.00/sdk/dNewton/ndWorld.cpp
+++ b/newton-4.00/sdk/dNewton/ndWorld.cpp
@@ -207,12 +207,12 @@ void ndWorld::SelectSolver(ndSolverModes solverMode)
 				m_solverMode = solverMode;
 				m_solver = new ndDynamicsUpdateSoa(this);
 				break;
-
+#ifdef _USE_VECTOR_AVX
 			case ndSimdAvx2Solver:
 				m_solverMode = solverMode;
 				m_solver = new ndDynamicsUpdateAvx2(this);
 				break;
-
+#endif // _USE_VECTOR_AVX
 			case ndOpenclSolver:
 				m_solverMode = solverMode;
 				m_solver = new ndDynamicsUpdateOpencl(this);


### PR DESCRIPTION
At this moment, compiling fails if AVX is not enabled. First, because the code using AVX is not excluded from the list of files to be compiled. And second, because there is no macro guard to not attempt to use that code if AVX was not enabled.

This change makes it so that files containing `Avx` in their name are excluded from the list of files to be compiled (_fixes the compiler failure_). And also adds a macro to not attempt to use code from those files since they were excluded (_fixes the linker failure that inevitably comes after the first change_).