### PR TITLE
MinGW implements `_strlwr`.

### DIFF
--- a/newton-4.00/applications/ndSandbox/ndSandboxStdafx.h
+++ b/newton-4.00/applications/ndSandbox/ndSandboxStdafx.h
@@ -96,8 +96,8 @@
 		#define stricmp strcasecmp
 	#endif
 
-	#ifndef _strlwr
-		inline char* _strlwr (char* const ptr) 
+	#if !defined(_strlwr) && (!defined(__MINGW32__) || !defined(__MINGW64__))
+		inline char* _strlwr (char* const ptr)
 		{ 
 			char* ret = ptr; 
 			while (*ret != '\0')

--- a/newton-4.00/applications/ndSandbox/ndSandboxStdafx.h
+++ b/newton-4.00/applications/ndSandbox/ndSandboxStdafx.h
@@ -96,7 +96,7 @@
 		#define stricmp strcasecmp
 	#endif
 
-	#if !defined(_strlwr) && (!defined(__MINGW32__) || !defined(__MINGW64__))
+	#if !defined(_strlwr) && !(defined(__MINGW32__) || defined(__MINGW64__))
 		inline char* _strlwr (char* const ptr)
 		{ 
 			char* ret = ptr; 


### PR DESCRIPTION
Not guarding against MinGW will lead to linker errors because MinGW satisfies the requirement from the outer guard `#ifndef _MSC_VER` but also doesn't fall into the GNUC category because it retains MSVC compatibility.