### PR TITLE
Include <malloc.h> in dMathDefines.h for Visual Studio 2022

### DIFF
--- a/newton-3.14/sdk/dMath/dMathDefines.h
+++ b/newton-3.14/sdk/dMath/dMathDefines.h
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <malloc.h>
 
 #ifdef _MSC_VER
 	#include <windows.h>


### PR DESCRIPTION
Visual Studio 2022 apparently changed something in how their c runtime headers are arranged so that the "alloc()" function is not available with the current set of include files.

Including <malloc.h> directly fixes the problem.