### PR TITLE
Changes

### DIFF
--- a/newton-4.00/applications/ndSandbox/CMakeLists.txt
+++ b/newton-4.00/applications/ndSandbox/CMakeLists.txt
@@ -78,21 +78,8 @@ if(MSVC OR MINGW)
 		endif()
 	endif()
 
-	if (PTR_SIZE EQUAL 8)
-		target_link_libraries (${projectName} ${CMAKE_SOURCE_DIR}/thirdParty/openalRuntime/win64sdk/lib/OpenAL_32.lib)
-		add_custom_command(
-			TARGET ${projectName} POST_BUILD
-			COMMAND ${CMAKE_COMMAND}
-			ARGS -E copy ${CMAKE_SOURCE_DIR}/thirdParty/openalRuntime/win64sdk/bin/OpenAL_32.dll ${PROJECT_BINARY_DIR}/applications/ndSandbox/${CMAKE_CFG_INTDIR})
-	else()
-		target_link_libraries (${projectName} ${CMAKE_SOURCE_DIR}/thirdParty/openalRuntime/win32sdk/lib/OpenAL_32.lib)
-		add_custom_command(
-			TARGET ${projectName} POST_BUILD
-			COMMAND ${CMAKE_COMMAND}
-			ARGS -E copy ${CMAKE_SOURCE_DIR}/thirdParty/openalRuntime/win32sdk/bin/OpenAL_32.dll ${PROJECT_BINARY_DIR}/applications/ndSandbox/${CMAKE_CFG_INTDIR})
-	endif()
 
-    target_link_libraries (${projectName} glu32 opengl32)
+    target_link_libraries (${projectName} glu32 opengl32 OpenAL_32)
 
 	target_link_options(${projectName} PUBLIC "/DEBUG") 
 

--- a/newton-4.00/applications/ndSandbox/demos/ndBasicParticleFluid.cpp
+++ b/newton-4.00/applications/ndSandbox/demos/ndBasicParticleFluid.cpp
@@ -88,8 +88,8 @@ class ndIsoSurfaceParticleVolume : public ndBodySphFluid
 		m_points.SetCount(points.GetCount() * 3);
 		m_indexList.SetCount(points.GetCount() * 3);
 
-		ndFloat32* const posit = &m_points[0].m_posit.m_x;
-		ndFloat32* const normal = &m_points[0].m_normal.m_x;
+		ndFloat32* const posit = (ndFloat32*)&m_points[0].m_posit.m_x;
+		ndFloat32* const normal = (ndFloat32*)&m_points[0].m_normal.m_x;
 		ndInt32 pointCount = m_isoSurface.GenerateListIndexList(&m_indexList[0], sizeof (glPositionNormalUV)/sizeof (GLfloat), posit, normal);
 
 		const ndVector origin(m_isoSurface.GetOrigin());

--- a/newton-4.00/applications/ndSandbox/ndSandboxStdafx.cpp
+++ b/newton-4.00/applications/ndSandbox/ndSandboxStdafx.cpp
@@ -68,8 +68,8 @@ void dGetWorkingFileName (const char* const name, char* const outPathName)
 		_strlwr (appPath);
 
 		char* const end = strstr (appPath, "applications");
-		end [0] = 0;
-		sprintf (outPathName, "%sapplications/media/%s", appPath, name);
+		//end [0] = 0;
+		sprintf (outPathName, "%s\\..\\applications\\media\\%s", appPath, name);
 	#elif defined(__APPLE__)
         char tmp[2048];
 		CFURLRef appURL (CFBundleCopyBundleURL(CFBundleGetMainBundle()));

--- a/newton-4.00/sdk/dCollision/ndBodyNotify.cpp
+++ b/newton-4.00/sdk/dCollision/ndBodyNotify.cpp
@@ -26,15 +26,38 @@
 
 D_CLASS_REFLECTION_IMPLEMENT_LOADER(ndBodyNotify)
 
-ndBodyNotify::ndBodyNotify(const ndLoadSaveBase::ndLoadDescriptor& desc)
-	:ndContainersFreeListAlloc<ndBodyNotify>()
-	,m_body(nullptr)
+
+
+
+
+
+
+
+ndBody* ndBodyNotify::GetBody()
+{ return nullptr; }
+
+const ndBody* ndBodyNotify::GetBody() const
+{ return nullptr; }
+
+void* ndBodyNotify::GetUserData() const
+{ return nullptr; }
+
+ndVector ndBodyNotify::GetGravity() const
 {
-	const nd::TiXmlNode* const rootNode = desc.m_rootNode;
-	m_defualtGravity = xmlGetVector3(rootNode, "gravity");
+	return m_defualtGravity;
 }
 
-void ndBodyNotify::OnApplyExternalForce(ndInt32, ndFloat32)
+void ndBodyNotify::SetGravity(const ndVector & defualtGravity)
+{
+	m_defualtGravity = defualtGravity;
+}
+
+
+
+void ndBodyNotify::OnTransform(ndInt32 threadIndex, const ndMatrix& matrix)
+{}
+
+void ndBodyNotify::OnApplyExternalForce(ndInt32 threadIndex, ndFloat32 timestep)
 {
 	ndBodyKinematic* const body = GetBody()->GetAsBodyKinematic();
 	dAssert(body);

--- a/newton-4.00/sdk/dCollision/ndBodyNotify.cpp
+++ b/newton-4.00/sdk/dCollision/ndBodyNotify.cpp
@@ -34,10 +34,10 @@ D_CLASS_REFLECTION_IMPLEMENT_LOADER(ndBodyNotify)
 
 
 ndBody* ndBodyNotify::GetBody()
-{ return nullptr; }
+{ return m_body; }
 
 const ndBody* ndBodyNotify::GetBody() const
-{ return nullptr; }
+{ return m_body; }
 
 void* ndBodyNotify::GetUserData() const
 { return nullptr; }

--- a/newton-4.00/sdk/dCollision/ndBodyNotify.h
+++ b/newton-4.00/sdk/dCollision/ndBodyNotify.h
@@ -31,17 +31,35 @@ class ndBodyNotify : public ndContainersFreeListAlloc<ndBodyNotify>
 {
 	public:  
 	D_CLASS_REFLECTION(ndBodyNotify);
-	ndBodyNotify(const ndVector& defualtGravity);
-	D_COLLISION_API ndBodyNotify(const ndLoadSaveBase::ndLoadDescriptor& desc);
-	virtual ~ndBodyNotify();
 
-	ndBody* GetBody();
-	const ndBody* GetBody() const;
-	virtual void* GetUserData() const;
-	ndVector GetGravity() const;
-	void SetGravity(const ndVector& defualtGravity);
 
-	virtual void OnTransform(ndInt32 threadIndex, const ndMatrix& matrix);
+	
+	D_COLLISION_API ndBodyNotify(const ndVector& defualtGravity) : ndContainersFreeListAlloc<ndBodyNotify>()
+		, m_defualtGravity(defualtGravity)
+		, m_body(nullptr)
+	{
+
+	}
+
+	D_COLLISION_API ndBodyNotify(const ndLoadSaveBase::ndLoadDescriptor& desc)
+		:ndContainersFreeListAlloc<ndBodyNotify>()
+		, m_body(nullptr)
+	{
+		const nd::TiXmlNode* const rootNode = desc.m_rootNode;
+		m_defualtGravity = xmlGetVector3(rootNode, "gravity");
+	}
+
+
+
+	D_COLLISION_API virtual ~ndBodyNotify() = default;
+
+	D_COLLISION_API ndBody* GetBody();
+	D_COLLISION_API const ndBody* GetBody() const;
+	D_COLLISION_API virtual void* GetUserData() const;
+	D_COLLISION_API ndVector GetGravity() const;
+	D_COLLISION_API void SetGravity(const ndVector& defualtGravity);
+
+	D_COLLISION_API virtual void OnTransform(ndInt32 threadIndex, const ndMatrix& matrix);
 
 	D_COLLISION_API virtual void Save(const ndLoadSaveBase::ndSaveDescriptor& desc) const;
 	D_COLLISION_API virtual void OnApplyExternalForce(ndInt32 threadIndex, ndFloat32 timestep);
@@ -52,47 +70,6 @@ class ndBodyNotify : public ndContainersFreeListAlloc<ndBodyNotify>
 	friend class ndBody;
 
 } D_GCC_NEWTON_ALIGN_32;
-
-inline ndBodyNotify::ndBodyNotify(const ndVector& defualtGravity)
-	:ndContainersFreeListAlloc<ndBodyNotify>()
-	,m_defualtGravity(defualtGravity & ndVector::m_triplexMask)
-	,m_body(nullptr)
-{
-}
-
-inline ndBodyNotify::~ndBodyNotify()
-{
-}
-
-inline ndBody* ndBodyNotify::GetBody()
-{
-	return m_body;
-}
-
-inline const ndBody* ndBodyNotify::GetBody() const
-{
-	return m_body;
-}
-
-inline ndVector ndBodyNotify::GetGravity() const
-{
-	return m_defualtGravity;
-}
-
-inline void ndBodyNotify::SetGravity(const ndVector& defualtGravity)
-{
-	m_defualtGravity = defualtGravity & ndVector::m_triplexMask;
-}
-
-
-inline void* ndBodyNotify::GetUserData() const
-{
-	return nullptr;
-}
-
-inline void ndBodyNotify::OnTransform(ndInt32, const ndMatrix&)
-{
-}
 
 #endif 
 

--- a/newton-4.00/sdk/dCollision/ndShapeInstance.cpp
+++ b/newton-4.00/sdk/dCollision/ndShapeInstance.cpp
@@ -160,8 +160,8 @@ ndShapeInstance& ndShapeInstance::operator=(const ndShapeInstance& instance)
 	m_shapeMaterial = instance.m_shapeMaterial;
 	m_skinThickness = instance.m_skinThickness;
 	m_collisionMode = instance.m_collisionMode;
-
-	m_shape->Release();
+	if(m_shape != nullptr)
+		m_shape->Release();
 	m_shape = instance.m_shape->AddRef();
 	m_ownerBody = instance.m_ownerBody;
 

--- a/newton-4.00/thirdParty/CMakeLists.txt
+++ b/newton-4.00/thirdParty/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NEWTON_BUILD_SANDBOX_DEMOS)
 	endif(MSVC OR MINGW)
 
     add_subdirectory(imgui)
-	#add_subdirectory(openAL)
+	add_subdirectory(openalSource)
 	add_subdirectory(glatter)
 	add_subdirectory(openFBX/src)
 endif()


### PR DESCRIPTION
When building a project from cmake, OpenAL seems to build from source ok and can just be linked to and architecture aligns automatically because its build from source.

Moved some functions in ndBodyNotify to .cpp.

avoid crash if shape instance is copied from another with and a shape hasn't yet been assigned.



