### PR TITLE
Only include malloc.h in dMathDefines.h ifdef _MSC_VER

### DIFF
--- a/newton-3.14/sdk/dMath/dMathDefines.h
+++ b/newton-3.14/sdk/dMath/dMathDefines.h
@@ -19,7 +19,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-#include <malloc.h>
+#ifdef _MSC_VER
+  #include <malloc.h>
+#endif
 
 #ifdef _MSC_VER
 	#include <windows.h>


### PR DESCRIPTION
To avoid breaking Mac OSX builds, while still allowing visual studio 22 to build the library.

Supposedly fixes https://github.com/MADEAPPS/newton-dynamics/issues/276