### PR TITLE
Simple Github Action and RPath fix on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: build and run tests
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build And Install Newton
+      run: |
+        cd newton-4.00
+        cmake -S . -B build/ -DNEWTON_BUILD_SANDBOX_DEMOS=OFF
+        cmake --build build -j2
+        sudo cmake --build build --target install
+
+    - name: Build And Run Hello World App
+      run: |
+        cp -r newton-4.00/applications/hello-world /tmp/myapp
+        cd /tmp/myapp
+        cmake -S . -B build/
+        cmake --build build/
+        echo ""
+        build/newton-hello-world

--- a/newton-4.00/CMakeLists.txt
+++ b/newton-4.00/CMakeLists.txt
@@ -77,7 +77,35 @@ endif(APPLE)
 
 #check for UNIX
 if(UNIX)
-    set(CMAKE_POLICY_DEFAULT_CMP0072 NEW)
+  # ----------------------------------------------------------------------
+  # Ensure the RPATH for libndNewton is set correctly both inside the build
+  # tree as well as in the installed location (ie after `make install`).
+  #
+  # The following settings were adapted from here
+  # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+
+  # Use the full RPATH for the build tree.
+  set(CMAKE_SKIP_BUILD_RPATH FALSE)
+
+  # Do not use the install RPATH during building but use later on when we install the library.
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+  # Set this RPATH in the installed library.
+  # NOTE: specify CMAKE_INSTALL_PREFIX as an absolute path or it will almost certainly not work.
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+  # Add the automatically determined parts of the RPATH which point to directories
+  # outside the build tree to the install RPATH.
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+  # Only use the RPATH if the target is not a system directory.
+  list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+  if("${isSystemDir}" STREQUAL "-1")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  endif("${isSystemDir}" STREQUAL "-1")
+  # ----------------------------------------------------------------------
+
+  set(CMAKE_POLICY_DEFAULT_CMP0072 NEW)
 	if(NOT NEWTON_BUILD_SHARED_LIBS)
 		add_compile_options(-fPIC)
 	endif()

--- a/newton-4.00/applications/hello-world/CMakeLists.txt
+++ b/newton-4.00/applications/hello-world/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Need 3.18+ because it adds the REQUIRED option for `find_library` call.
+cmake_minimum_required(VERSION 3.18.0 FATAL_ERROR)
+
+project("newton-hello-world")
+message (${PROJECT_NAME})
+
+# Where to find the installed Newton headers.
+include_directories(/usr/local/include/ndNewton)
+
+# Ensure the Newton libraries are installed.
+find_library(NEWTON_LIB ndNewton REQUIRED)
+find_library(AVX_LIB ndSolverAvx2 REQUIRED)
+
+# Build the app and link it to the Newton libraries.
+add_executable(${PROJECT_NAME} main.cpp testStdafx.cpp)
+target_link_libraries (${PROJECT_NAME} ${NEWTON_LIB} ${AVX_LIB} pthread)

--- a/newton-4.00/applications/hello-world/README.md
+++ b/newton-4.00/applications/hello-world/README.md
@@ -1,0 +1,24 @@
+## Minimal Standalone Newton Application with CMake (Linux)
+
+This recipe shows how to incorporate Newton into your own application.
+The application only depends on the installed library and headers, not on the
+Sandbox or the Newton build directory.
+
+The example below also runs as a [Github Action](../../../.github/workflows/build.yml).
+
+```bash
+# Build Newton.
+cd newton-4.00
+cmake -S . -B build/
+cmake --build build
+sudo cmake --build build --target install
+
+# Build the demo app (you can copy that folder anywhere, it does
+# not need to reside in Newton's original build folder).
+cd newton-4.00/applications/standalone
+cmake -S . -B build/
+cmake --build build/ -j2
+
+# Run the demo app.
+build/newton-hello-world
+```

--- a/newton-4.00/applications/hello-world/main.cpp
+++ b/newton-4.00/applications/hello-world/main.cpp
@@ -1,0 +1,127 @@
+/* Copyright (c) <2003-2019> <Newton Game Dynamics>
+*
+* This software is provided 'as-is', without any express or implied
+* warranty. In no event will the authors be held liable for any damages
+* arising from the use of this software.
+*
+* Permission is granted to anyone to use this software for any purpose,
+* including commercial applications, and to alter it and redistribute it
+* freely
+*/
+
+#include <iostream>
+#include "testStdafx.h"
+
+
+class ndDemoEntityNotify: public ndBodyNotify
+{
+  public:
+  ndDemoEntityNotify()
+    :ndBodyNotify(ndVector (0.0f, -10.0f, 0.0f, 0.0f))
+  {
+    // here we set the application user data that
+    // goes with the game engine, for now is just null
+    m_applicationUserData = nullptr;
+  }
+
+  //virtual void OnApplyExternalForce(ndInt32 threadIndex, ndFloat32 timestep)
+  virtual void OnApplyExternalForce(ndInt32, ndFloat32)
+  {
+    ndBodyDynamic* const dynamicBody = GetBody()->GetAsBodyDynamic();
+    if (dynamicBody)
+    {
+      ndVector massMatrix(dynamicBody->GetMassMatrix());
+      ndVector force(ndVector(0.0f, -10.0f, 0.0f, 0.0f).Scale(massMatrix.m_w));
+      dynamicBody->SetForce(force);
+      dynamicBody->SetTorque(ndVector::m_zero);
+    }
+  }
+
+  //virtual void OnTransform(ndInt32 threadIndex, const ndMatrix& matrix)
+  virtual void OnTransform(ndInt32, const ndMatrix&)
+  {
+    // apply this transformation matrix to the application user data.
+    //dAssert(0);
+  }
+
+  void* m_applicationUserData;
+};
+
+ndVector FindFloor(const ndWorld& world, const ndVector& origin, ndFloat32 dist)
+{
+  // shot a vertical ray from a high altitude and collect the intersection parameter.
+  ndVector p0(origin);
+  ndVector p1(origin - ndVector(0.0f, ndAbs(dist), 0.0f, 0.0f));
+
+  ndRayCastClosestHitCallback rayCaster;
+  world.RayCast(rayCaster, p0, p1);
+  return (rayCaster.m_param < 1.0f) ? rayCaster.m_contact.m_point : p0;
+}
+
+ndBodyDynamic* BuildFloorBox(ndWorld& world)
+{
+  world.Sync();
+  ndShapeInstance box(new ndShapeBox(200.0f, 1.0f, 200.f));
+  ndBodyDynamic* const body = new ndBodyDynamic();
+
+  ndMatrix matrix(ndGetIdentityMatrix());
+  matrix.m_posit.m_y = -0.5f;
+
+  body->SetNotifyCallback(new ndDemoEntityNotify);
+  body->SetMatrix(matrix);
+  body->SetCollisionShape(box);
+  world.AddBody(body);
+  return body;
+}
+
+ndBodyDynamic* BuildSphere(ndWorld& world, ndFloat32 mass, const ndVector& origin, const ndFloat32 diameter, ndFloat32 offsetHigh)
+{
+  ndMatrix matrix(ndGetIdentityMatrix());
+  matrix.m_posit = origin;
+  matrix.m_posit.m_w = 1.0f;
+
+  world.Sync();
+
+  ndShapeInstance sphere(new ndShapeSphere(diameter * 0.5f));
+
+  ndVector floor(FindFloor(world, matrix.m_posit + ndVector(0.0f, 100.0f, 0.0f, 0.0f), 200.0f));
+  matrix.m_posit.m_y = floor.m_y + diameter * 0.5f * 0.99f;
+
+  matrix.m_posit.m_y += offsetHigh;
+
+  ndBodyDynamic* const body = new ndBodyDynamic();
+  body->SetNotifyCallback(new ndDemoEntityNotify);
+  body->SetMatrix(matrix);
+  body->SetCollisionShape(sphere);
+  body->SetMassMatrix(mass, sphere);
+  world.AddBody(body);
+  return body;
+}
+
+int main(int, const char*)
+{
+  ndWorld world;
+  world.SetSubSteps(1);
+
+  ndVector size(0.5f, 0.25f, 0.8f, 0.0f);
+
+  ndVector origin(0.0f, 0.0f, 0.0f, 0.0f);
+  ndBodyDynamic* bodyFloor = BuildFloorBox(world);
+  ndBodyDynamic* bodySphere = BuildSphere(world, 1.0f, origin + ndVector(3.0f, 0.0f, 0.0f, 0.0f), 1.0f, 1.0f);
+
+  ndJointSpherical joint(bodySphere->GetMatrix(), bodySphere, bodyFloor);
+
+  ndFloat32 totalTime = 0;
+  for (ndInt32 i = 0; i < 10000; i++)
+  {
+    if (i == 0) world.AddJoint(&joint);
+    if (i == 2) world.RemoveJoint(&joint);
+
+    world.Update(1.0f / 60.0f);
+    totalTime += world.GetUpdateTime();
+    world.Sync();
+
+  }
+  std::cout << "Newton demo completed successfully\n";
+  return 0;
+}

--- a/newton-4.00/applications/hello-world/testStdafx.cpp
+++ b/newton-4.00/applications/hello-world/testStdafx.cpp
@@ -1,0 +1,13 @@
+/* Copyright (c) <2003-2019> <Newton Game Dynamics>
+*
+* This software is provided 'as-is', without any express or implied
+* warranty. In no event will the authors be held liable for any damages
+* arising from the use of this software.
+*
+* Permission is granted to anyone to use this software for any purpose,
+* including commercial applications, and to alter it and redistribute it
+* freely
+*/
+
+#include "testStdafx.h"
+

--- a/newton-4.00/applications/hello-world/testStdafx.h
+++ b/newton-4.00/applications/hello-world/testStdafx.h
@@ -1,0 +1,20 @@
+/* Copyright (c) <2003-2019> <Newton Game Dynamics>
+*
+* This software is provided 'as-is', without any express or implied
+* warranty. In no event will the authors be held liable for any damages
+* arising from the use of this software.
+*
+* Permission is granted to anyone to use this software for any purpose,
+* including commercial applications, and to alter it and redistribute it
+* freely
+*/
+
+#ifndef _TEST_SDT_AFTX_H_
+#define _TEST_SDT_AFTX_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <ndNewton.h>
+
+#endif
+


### PR DESCRIPTION
Hi,

I just tried out Newton on Linux and ran into a small linker problem.
Essentially, I could not link my app to the installed Newton libraries, ie the
ones created by `make install` (the ones in the build folder work fine).

The problem was due to some missing RPath settings in [CMakeLists.txt](newton-4.00/CMakeLists.text) 
which this PR addresses.

The PR also adds a simple GitHub Action to build Newton as well as a minimal
Hello World program. The Hello World app is just a stripped down but standalone
version of [ndTest](newton-4.00/applications/ndTest) to ensure everything works as intended on Linux.

The GitHub Action should also provide instant feedback from now on whenever the
Linux build breaks for any reason.

I hope you find this useful.
