### PR TITLE
Use 2 sub-steps in all hello world demos.

### DIFF
--- a/newton-4.00/applications/hello-world/contactCallback.cpp
+++ b/newton-4.00/applications/hello-world/contactCallback.cpp
@@ -80,7 +80,10 @@ int main(int, const char**)
 {
   // Setup the world itself.
   ndWorld world;
-  world.SetSubSteps(1);
+
+  // Two sub-steps per time step is the recommended default. It should provide
+  // stable simulations for most standard scenarios including those with joints.
+  world.SetSubSteps(2);
 
   // Install global callback handler for various contact events like
   // AABB overlap and genuine contacts.

--- a/newton-4.00/applications/hello-world/hello.cpp
+++ b/newton-4.00/applications/hello-world/hello.cpp
@@ -20,7 +20,10 @@ int main(int, const char**)
 
   // Create the world.
   ndWorld world;
-  world.SetSubSteps(1);
+
+  // Two sub-steps per time step is the recommended default. It should provide
+  // stable simulations for most standard scenarios including those with joints.
+  world.SetSubSteps(2);
 
   // Step the world and measure how long it takes.
   ndFloat32 totalTime = 0;

--- a/newton-4.00/applications/hello-world/transformCallback.cpp
+++ b/newton-4.00/applications/hello-world/transformCallback.cpp
@@ -80,7 +80,10 @@ int main(int, const char**)
 {
   // Setup the world itself.
   ndWorld world;
-  world.SetSubSteps(1);
+
+  // Two sub-steps per time step is the recommended default. It should provide
+  // stable simulations for most standard scenarios including those with joints.
+  world.SetSubSteps(2);
 
   // Add a single sphere to the world.
   ndBodyDynamic *sphere = BuildSphere();


### PR DESCRIPTION
This PR increases the number of sub-steps in the hello world demos to 2 as recommended by @JulioJerez in #291 

After looking over [ndTest](newton-4.00/applications/ndTest/main.cpp) once more I noticed calls to `world.Sync()` in various places, eg after stepping the simulation but also before creating new bodies. What exactly does this do and, more importantly, when do end user need to worry about it?