### PR TITLE
Fix variable name in ndBodyNotify: defualtGravity -> defaultGravity

### DIFF
--- a/newton-4.00/sdk/dCollision/ndBodyNotify.cpp
+++ b/newton-4.00/sdk/dCollision/ndBodyNotify.cpp
@@ -27,9 +27,9 @@
 D_CLASS_REFLECTION_IMPLEMENT_LOADER(ndBodyNotify)
 
 
-ndBodyNotify::ndBodyNotify(const ndVector& defualtGravity)
+ndBodyNotify::ndBodyNotify(const ndVector& defaultGravity)
 	:ndContainersFreeListAlloc<ndBodyNotify>()
-	,m_defualtGravity(defualtGravity)
+	,m_defaultGravity(defaultGravity)
 	,m_body(nullptr)
 {
 }
@@ -39,7 +39,7 @@ ndBodyNotify::ndBodyNotify(const ndLoadSaveBase::ndLoadDescriptor& desc)
 	,m_body(nullptr)
 {
 	const nd::TiXmlNode* const rootNode = desc.m_rootNode;
-	m_defualtGravity = xmlGetVector3(rootNode, "gravity");
+	m_defaultGravity = xmlGetVector3(rootNode, "gravity");
 }
 
 ndBodyNotify::~ndBodyNotify()
@@ -52,7 +52,7 @@ void ndBodyNotify::Save(const ndLoadSaveBase::ndSaveDescriptor& desc) const
 	nd::TiXmlElement* const childNode = new nd::TiXmlElement(ClassName());
 	desc.m_rootNode->LinkEndChild(childNode);
 
-	xmlSaveParam(childNode, "gravity", m_defualtGravity);
+	xmlSaveParam(childNode, "gravity", m_defaultGravity);
 }
 
 ndBody* ndBodyNotify::GetBody()
@@ -72,12 +72,12 @@ void* ndBodyNotify::GetUserData() const
 
 ndVector ndBodyNotify::GetGravity() const
 {
-	return m_defualtGravity;
+	return m_defaultGravity;
 }
 
-void ndBodyNotify::SetGravity(const ndVector & defualtGravity)
+void ndBodyNotify::SetGravity(const ndVector & defaultGravity)
 {
-	m_defualtGravity = defualtGravity;
+	m_defaultGravity = defaultGravity;
 }
 
 void ndBodyNotify::OnTransform(ndInt32, const ndMatrix&)
@@ -91,7 +91,7 @@ void ndBodyNotify::OnApplyExternalForce(ndInt32, ndFloat32)
 	if (body->GetInvMass() > 0.0f)
 	{
 		ndVector massMatrix(body->GetMassMatrix());
-		ndVector force (m_defualtGravity.Scale(massMatrix.m_w));
+		ndVector force (m_defaultGravity.Scale(massMatrix.m_w));
 		body->SetForce(force);
 		body->SetTorque(ndVector::m_zero);
 

--- a/newton-4.00/sdk/dCollision/ndBodyNotify.h
+++ b/newton-4.00/sdk/dCollision/ndBodyNotify.h
@@ -31,7 +31,7 @@ class ndBodyNotify : public ndContainersFreeListAlloc<ndBodyNotify>
 {
 	public:  
 	D_CLASS_REFLECTION(ndBodyNotify);
-	D_COLLISION_API ndBodyNotify(const ndVector& defualtGravity);
+	D_COLLISION_API ndBodyNotify(const ndVector& defaultGravity);
 	D_COLLISION_API ndBodyNotify(const ndLoadSaveBase::ndLoadDescriptor& desc);
 
 	D_COLLISION_API virtual ~ndBodyNotify();
@@ -40,7 +40,7 @@ class ndBodyNotify : public ndContainersFreeListAlloc<ndBodyNotify>
 	D_COLLISION_API const ndBody* GetBody() const;
 	D_COLLISION_API virtual void* GetUserData() const;
 	D_COLLISION_API ndVector GetGravity() const;
-	D_COLLISION_API void SetGravity(const ndVector& defualtGravity);
+	D_COLLISION_API void SetGravity(const ndVector& defaultGravity);
 
 	D_COLLISION_API virtual void OnTransform(ndInt32 threadIndex, const ndMatrix& matrix);
 
@@ -48,7 +48,7 @@ class ndBodyNotify : public ndContainersFreeListAlloc<ndBodyNotify>
 	D_COLLISION_API virtual void OnApplyExternalForce(ndInt32 threadIndex, ndFloat32 timestep);
 
 	private:
-	ndVector m_defualtGravity;
+	ndVector m_defaultGravity;
 	ndBody* m_body;
 	friend class ndBody;
 


### PR DESCRIPTION
Fixed a typo in a variable name. The engine and all demos compile fine.

I am not sure how dangerous this change would be for existing applications, so please feel free to close the PR without merging it if you think it is too risky.