### PR TITLE
Build Newton in Windows based Github Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,32 @@ jobs:
 
         echo -e "\n\n---------- ContactCallback\n"
         build/contactCallback
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Windows
+      shell: bash
+      run: |
+        choco install ninja cmake
+        cmake --version
+        ninja --version
+
+    - name: Build And Install Newton
+      shell: bash
+      run: |
+        cd newton-4.00
+        cmake \
+            -S . -B build \
+            -DNEWTON_BUILD_SANDBOX_DEMOS=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -G "Visual Studio 17 2022" -A x64 \
+            -DCMAKE_INSTALL_PREFIX:PATH=out
+
+        cmake --build build -j2
+
+        # The installation target does not currently work.
+        # cmake --install build --strip
+


### PR DESCRIPTION
Add a Github Action to build Newton on Windows.

The compilation of the core engine works but the installation with `cmake
--install build --strip` fails on Windows. It appears the installer is looking for the libraries in the wrong folder. Maybe someone on Windows can try the command sequence locally to debug/confirm the problem?

As a consequence of this, the Windows Action also does not build the hello world demos yet.