### PR TITLE
Remove PThread dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup Linux
       shell: bash
@@ -56,7 +56,7 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup Windows
       shell: bash

--- a/newton-4.00/applications/hello-world/CMakeLists.txt
+++ b/newton-4.00/applications/hello-world/CMakeLists.txt
@@ -19,15 +19,15 @@ find_library(AVX_LIB ndSolverAvx2 REQUIRED)
 
 project("hello")
 add_executable(${PROJECT_NAME} hello.cpp)
-target_link_libraries (${PROJECT_NAME} ${NEWTON_LIB} ${AVX_LIB} pthread)
+target_link_libraries (${PROJECT_NAME} ${NEWTON_LIB} ${AVX_LIB})
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
 
 project("transformCallback")
 add_executable(${PROJECT_NAME} transformCallback.cpp)
-target_link_libraries (${PROJECT_NAME} ${NEWTON_LIB} ${AVX_LIB} pthread)
+target_link_libraries (${PROJECT_NAME} ${NEWTON_LIB} ${AVX_LIB})
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
 
 project("contactCallback")
 add_executable(${PROJECT_NAME} contactCallback.cpp)
-target_link_libraries (${PROJECT_NAME} ${NEWTON_LIB} ${AVX_LIB} pthread)
+target_link_libraries (${PROJECT_NAME} ${NEWTON_LIB} ${AVX_LIB})
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall)

--- a/newton-4.00/tests/CMakeLists.txt
+++ b/newton-4.00/tests/CMakeLists.txt
@@ -50,6 +50,6 @@ target_link_libraries(
   ${PROJECT_NAME}
   GTest::gtest_main
 )
-target_link_libraries (${PROJECT_NAME} ndNewton ndSolverAvx2 pthread)
+target_link_libraries (${PROJECT_NAME} ndNewton ndSolverAvx2)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
 gtest_discover_tests(${PROJECT_NAME})


### PR DESCRIPTION
- Remove the unnecessary `pthread` dependency.
- Upgrade `actions/checkout` to `v3` to silence a harmless CI warning about an old Node version.