### PR TITLE
Run unit tests in CI for Windows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,3 +81,14 @@ jobs:
         # The installation target does not currently work.
         # cmake --install build --strip
 
+    - name: Run Tests
+      shell: bash
+      run: |
+        # We need to copy the "newton_test" binary into the folder with
+        # the Windows DLL files first before we can run it.
+        cd newton-4.00/build/sdk/Debug
+        cp ../../tests/Debug/newton_tests.exe ./
+
+        # Execute the test suite.
+        ./newton_tests
+

--- a/newton-4.00/CMakeLists.txt
+++ b/newton-4.00/CMakeLists.txt
@@ -199,7 +199,5 @@ endif()
 add_subdirectory(sdk)
 add_subdirectory(thirdParty)
 add_subdirectory(applications)
+add_subdirectory(tests)
 
-if (NOT MSVC OR NEWTON_BUILD_TEST)
-	add_subdirectory(tests)
-endif()

--- a/newton-4.00/tests/CMakeLists.txt
+++ b/newton-4.00/tests/CMakeLists.txt
@@ -52,4 +52,3 @@ target_link_libraries(
 )
 target_link_libraries (${PROJECT_NAME} ndNewton ndSolverAvx2)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
-gtest_discover_tests(${PROJECT_NAME})


### PR DESCRIPTION
Automatically build and run the test suite in the Windows runners as well.

I suggest to leave this PR open until the Linux build works again. I can then
rebase it to the latest version and verify it works on both platforms.
